### PR TITLE
fix: Use target x velocity to determine collision look ahead direction

### DIFF
--- a/src/path_tracking_pid_local_planner.cpp
+++ b/src/path_tracking_pid_local_planner.cpp
@@ -421,7 +421,8 @@ uint8_t TrackingPidLocalPlanner::projectedCollisionCost()
 
   // Define a x_step transform which will be used to step forward the position.
   tf2::Transform x_step_tf;
-  x_step_tf.setOrigin(tf2::Vector3(copysign(x_resolution, x_vel), 0.0, 0.0));
+  double target_x_vel = pid_controller_.getConfig().target_x_vel;
+  x_step_tf.setOrigin(tf2::Vector3(copysign(x_resolution, target_x_vel), 0.0, 0.0));
 
   // Use a controller state to forward project the position on the path
   ControllerState projected_controller_state = pid_controller_.getControllerState();

--- a/src/path_tracking_pid_local_planner.cpp
+++ b/src/path_tracking_pid_local_planner.cpp
@@ -422,7 +422,8 @@ uint8_t TrackingPidLocalPlanner::projectedCollisionCost()
   // Define a x_step transform which will be used to step forward the position.
   tf2::Transform x_step_tf;
   double target_x_vel = pid_controller_.getConfig().target_x_vel;
-  x_step_tf.setOrigin(tf2::Vector3(copysign(x_resolution, target_x_vel), 0.0, 0.0));
+  double max_abs_x_vel = std::abs(x_vel) > std::abs(target_x_vel) ? x_vel : target_x_vel;
+  x_step_tf.setOrigin(tf2::Vector3(copysign(x_resolution, max_abs_x_vel), 0.0, 0.0));
 
   // Use a controller state to forward project the position on the path
   ControllerState projected_controller_state = pid_controller_.getControllerState();


### PR DESCRIPTION
**Issue:**
When stopping for an obstacle whilst driving backwards, the robot will come to a standstill. Thereafter the configured `collision_look_ahead_length_offset` is applied forwards as  `copysign(0) = 1` (see [here](https://github.com/nobleo/path_tracking_pid/blob/main/src/path_tracking_pid_local_planner.cpp#L424)). This results in the robot creeping towards the obstacle until the footprint reaches the obstacle (see gif)

**Solution:**
Use the target velocity (`target_x_vel`) instead.    

![path_tracking_pid collision](https://user-images.githubusercontent.com/43780894/151982547-f5c10507-e10e-409e-a038-ab635e1547c2.gif)

