### PR TITLE
Fix `IndexError: list index out of range`

### DIFF
--- a/test/test_path_tracking_pid_bw_turn_cancel.py
+++ b/test/test_path_tracking_pid_bw_turn_cancel.py
@@ -34,9 +34,9 @@ class TestPathTrackingPID(unittest.TestCase):
 
     def vis_cb(self, msg):
         if msg.ns == 'control point':
-            self.carrot = msg.points[0]
+            self.carrot = msg.pose.position
         elif msg.ns == 'plan point':
-            self.pos_on_plan = msg.points[0]
+            self.pos_on_plan = msg.pose.position
 
         # Only start checking when both markers are received
         if self.carrot is None or self.pos_on_plan is None:

--- a/test/test_path_tracking_pid_bw_turn_cancel.py
+++ b/test/test_path_tracking_pid_bw_turn_cancel.py
@@ -68,7 +68,7 @@ class TestPathTrackingPID(unittest.TestCase):
         self.carrot = None
         self.pos_on_plan = None
         self.marker_angle = None
-        self.carrot_dir_flipped = False
+        self.carrot_dir_flipped = None
         # Subscribe to visualization-markers to track control direction
         self.vis_sub = rospy.Subscriber("move_base_flex/PathTrackingPID/visualization_marker", Marker, self.vis_cb)
 
@@ -98,7 +98,7 @@ class TestPathTrackingPID(unittest.TestCase):
         rospy.logwarn("Got result")
         self.assertTrue(preempt_in_time, msg="Action call didn't preempt in time")
 
-        self.assertFalse(self.carrot_dir_flipped, msg="Guiding direction flipped while stopping!")
+        self.assertTrue(self.carrot_dir_flipped is False, msg="Guiding direction flipped while stopping!")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
In #23 I've changed the visualization marker type. Apparently a test was asserting the output of that marker and giving the following error:
```
[ERROR] [1644845778.670021]: bad callback: <bound method TestPathTrackingPID.vis_cb of <__main__.TestPathTrackingPID testMethod=test_exepath_action>>                                                                                                    
Traceback (most recent call last):
  File "/opt/ros/noetic/lib/python3/dist-packages/rospy/topics.py", line 750, in _invoke_callback
    cb(msg)
  File "/home/ramon/ros/harvey/system/src/path_tracking_pid/test/test_path_tracking_pid_bw_turn_cancel.py", line 40, in vis_cb
    self.pos_on_plan = msg.points[0]
IndexError: list index out of range
```
I've fixed the test and made sure that these errors in the future will let the test fail properly.