### PR TITLE
Replaced macros with constants.

### DIFF
--- a/include/path_tracking_pid/controller.hpp
+++ b/include/path_tracking_pid/controller.hpp
@@ -19,9 +19,9 @@ template <typename T> int sign(T val) {
 namespace path_tracking_pid
 {
 
-#define RADIUS_EPS 0.001  // Smallest relevant radius [m]
-#define VELOCITY_EPS 1e-3  // Neglegible velocity
-#define LONG_DURATION 31556926  // A year (ros::Duration cannot be inf)
+inline constexpr double RADIUS_EPS = 0.001; // Smallest relevant radius [m]
+inline constexpr double VELOCITY_EPS = 1e-3; // Neglegible velocity
+inline constexpr double LONG_DURATION = 31556926; // A year (ros::Duration cannot be inf)
 
 enum class ControllerMode
 {

--- a/include/path_tracking_pid/controller.hpp
+++ b/include/path_tracking_pid/controller.hpp
@@ -19,9 +19,9 @@ template <typename T> int sign(T val) {
 namespace path_tracking_pid
 {
 
-inline constexpr double RADIUS_EPS = 0.001; // Smallest relevant radius [m]
-inline constexpr double VELOCITY_EPS = 1e-3; // Neglegible velocity
-inline constexpr double LONG_DURATION = 31556926; // A year (ros::Duration cannot be inf)
+inline constexpr double RADIUS_EPS = 0.001;        // Smallest relevant radius [m]
+inline constexpr double VELOCITY_EPS = 1e-3;       // Neglegible velocity
+inline constexpr double LONG_DURATION = 31556926;  // A year (ros::Duration cannot be inf)
 
 enum class ControllerMode
 {

--- a/include/path_tracking_pid/path_tracking_pid_local_planner.hpp
+++ b/include/path_tracking_pid/path_tracking_pid_local_planner.hpp
@@ -21,8 +21,8 @@
 #include "tf2_ros/buffer.h"
 #include "path_tracking_pid/visualization.hpp"
 
-#define MAP_PARALLEL_THRESH 0.2
-constexpr double DT_MAX=1.5;
+inline constexpr double MAP_PARALLEL_THRESH = 0.2;
+inline constexpr double DT_MAX = 1.5;
 
 
 BOOST_GEOMETRY_REGISTER_POINT_2D(geometry_msgs::Point, double, cs::cartesian, x, y)


### PR DESCRIPTION
Replaced all macros with constants.

See https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#es31-dont-use-macros-for-constants-or-functions