### PR TITLE
Moved constants to reduce scope.

### DIFF
--- a/include/path_tracking_pid/controller.hpp
+++ b/include/path_tracking_pid/controller.hpp
@@ -19,10 +19,6 @@ template <typename T> int sign(T val) {
 namespace path_tracking_pid
 {
 
-inline constexpr double RADIUS_EPS = 0.001;        // Smallest relevant radius [m]
-inline constexpr double VELOCITY_EPS = 1e-3;       // Neglegible velocity
-inline constexpr double LONG_DURATION = 31556926;  // A year (ros::Duration cannot be inf)
-
 enum class ControllerMode
 {
   frontAxleLateral = 0,

--- a/include/path_tracking_pid/path_tracking_pid_local_planner.hpp
+++ b/include/path_tracking_pid/path_tracking_pid_local_planner.hpp
@@ -21,9 +21,6 @@
 #include "tf2_ros/buffer.h"
 #include "path_tracking_pid/visualization.hpp"
 
-inline constexpr double MAP_PARALLEL_THRESH = 0.2;
-inline constexpr double DT_MAX = 1.5;
-
 
 BOOST_GEOMETRY_REGISTER_POINT_2D(geometry_msgs::Point, double, cs::cartesian, x, y)
 

--- a/src/common.hpp
+++ b/src/common.hpp
@@ -5,6 +5,8 @@
 namespace path_tracking_pid
 {
 
+inline constexpr double VELOCITY_EPS = 1e-3;  // Neglegible velocity
+
 // Converts an enumeration to its underlying type.
 template <typename enum_type>
 constexpr std::underlying_type_t<enum_type> to_underlying(enum_type value) noexcept

--- a/src/controller.cpp
+++ b/src/controller.cpp
@@ -4,6 +4,8 @@
 
 #include "path_tracking_pid/controller.hpp"
 
+#include "common.hpp"
+
 #include <limits>
 #include <vector>
 
@@ -12,6 +14,13 @@
 
 namespace path_tracking_pid
 {
+
+namespace {
+
+constexpr double RADIUS_EPS = 0.001;        // Smallest relevant radius [m]
+constexpr double LONG_DURATION = 31556926;  // A year (ros::Duration cannot be inf)
+
+} // namespace anonymous
 
 void Controller::setHolonomic(bool holonomic)
 {

--- a/src/path_tracking_pid_local_planner.cpp
+++ b/src/path_tracking_pid_local_planner.cpp
@@ -25,6 +25,14 @@ PLUGINLIB_EXPORT_CLASS(path_tracking_pid::TrackingPidLocalPlanner, mbf_costmap_c
 
 namespace path_tracking_pid
 {
+
+namespace {
+
+constexpr double MAP_PARALLEL_THRESH = 0.2;
+constexpr double DT_MAX = 1.5;
+
+} // namespace anonymous
+
 TrackingPidLocalPlanner::TrackingPidLocalPlanner() = default;
 
 TrackingPidLocalPlanner::~TrackingPidLocalPlanner() = default;


### PR DESCRIPTION
Reduced the scope of constants.

See https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#es5-keep-scopes-small