### PR TITLE
Distinguish between system and normal headers.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -69,11 +69,8 @@ add_library(${PROJECT_NAME}
 add_dependencies(${PROJECT_NAME} ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS} ${PROJECT_NAME}_gencfg)
 target_link_libraries(${PROJECT_NAME} ${catkin_LIBRARIES})
 
-include_directories(
-  include
-  ${catkin_INCLUDE_DIRS}
-  ${dynamic_reconfigure_PACKAGE_PATH}/cmake/cfgbuild.cmake
-)
+include_directories(SYSTEM ${catkin_INCLUDE_DIRS} ${dynamic_reconfigure_PACKAGE_PATH}/cmake/cfgbuild.cmake)
+include_directories(include)
 
 # Configure roslint for nodes
 


### PR DESCRIPTION
Distinguish between system header files (which are less strictly checked by the compiler and tools like clang-tidy) and normal header files. System header files should be used for header files which are not part of the current project/repo.

This allows us to use properly strict compiler settings.