### PR TITLE
Quaternion of carrotTF was not initialized, set to proper value

### DIFF
--- a/src/controller.cpp
+++ b/src/controller.cpp
@@ -132,8 +132,8 @@ void Controller::setPlan(geometry_msgs::Transform current_tf, geometry_msgs::Twi
   if (!track_base_link_enabled_)
   {
     // Add carrot length to plan using goal pose (we assume the last pose contains correct angle)
-    tf2::Transform carrotTF(tf2::Matrix3x3(1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0));
-    carrotTF.setOrigin(tf2::Vector3(l_, 0.0, 0.0));
+    tf2::Transform carrotTF(tf2::Matrix3x3(1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0),
+                            tf2::Vector3(l_, 0.0, 0.0));
     global_plan_tf_.push_back(last_transform * carrotTF);
   }
 

--- a/src/controller.cpp
+++ b/src/controller.cpp
@@ -132,7 +132,7 @@ void Controller::setPlan(geometry_msgs::Transform current_tf, geometry_msgs::Twi
   if (!track_base_link_enabled_)
   {
     // Add carrot length to plan using goal pose (we assume the last pose contains correct angle)
-    tf2::Transform carrotTF;
+    tf2::Transform carrotTF(tf2::Matrix3x3(1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0));
     carrotTF.setOrigin(tf2::Vector3(l_, 0.0, 0.0));
     global_plan_tf_.push_back(last_transform * carrotTF);
   }


### PR DESCRIPTION
As initiated here:
https://github.com/nobleo/path_tracking_pid/commit/f603fecff527321a9ee0165845981bd4fc578ad6#commitcomment-66762408
Building with proper flags threw a new error, this fixes it.

A `tf2::Transform` without arguments is not initialized, when calling `setOrigin()` the rotation part is still not initialized.