### PR TITLE
Removed dead code.

### DIFF
--- a/include/path_tracking_pid/controller.hpp
+++ b/include/path_tracking_pid/controller.hpp
@@ -306,11 +306,6 @@ private:
   double vel_max_external_ = INFINITY;  // Dynamic external max velocity requirement (e.g. no more power available)
   double vel_max_obstacle_ = INFINITY;  // Can be zero if lethal obstacles are detected
 
-  // Used in filter calculations. Default 1.0 corresponds to a cutoff frequency at
-  // 1/4 of the sample rate.
-  double c_lat_ = 1.;
-  double c_ang_ = 1.;
-
   // MPC settings
   int mpc_max_fwd_iter_;               // Define # of steps that you look into the future with MPC [-]
   int mpc_max_vel_optimization_iter_;  // Set maximum # of velocity bisection iterations


### PR DESCRIPTION
Removed dead code.

`cutoff_frequency_lat` and `cutoff_frequency_ang` are constants and both have the value -1. So the code that was only run if they were unequal to -1 could be removed. This in turn effectively made the member variables `c_lat_ ` and `c_ang_` constants.