### PR TITLE
Fixed signed/unsigned conversion warnings.

### DIFF
--- a/src/controller.cpp
+++ b/src/controller.cpp
@@ -185,38 +185,36 @@ void Controller::setPlan(geometry_msgs::Transform current_tf, geometry_msgs::Twi
   tf2::Transform deltaPlan;
   // We define segment0 to be the segment connecting pose0 and pose1.
   // Hence, when picking the starting path's pose, we mean to start at the segment connecting that and the next pose.
-  for (int idx_path = global_plan_tf_.size() - 2; idx_path >= 0; --idx_path)
+  for (auto idx_path = global_plan_tf_.size() - 1; idx_path > 0; --idx_path)
   {
     /* Get distance to segment to determine if this is the segment to start at */
-    dist_to_segment = distToSegmentSquared(current_tf2, global_plan_tf_[idx_path], global_plan_tf_[idx_path + 1]);
+    dist_to_segment = distToSegmentSquared(current_tf2, global_plan_tf_[idx_path - 1], global_plan_tf_[idx_path]);
     // Calculate 3D distance, since current_tf2 might have significant z-offset and roll/pitch values w.r.t. path-pose
     // When not doing this, we're brutely projecting in robot's frame and might snap to another segment!
     if (dist_to_segment < minimum_distance_to_path)
     {
       minimum_distance_to_path = dist_to_segment;
-      controller_state_.current_global_plan_index = idx_path;
+      controller_state_.current_global_plan_index = idx_path - 1;
     }
 
     /* Create distance and turning radius vectors once for usage later */
-    deltaPlan = global_plan_tf_[idx_path].inverseTimes(global_plan_tf_[idx_path + 1]);
+    deltaPlan = global_plan_tf_[idx_path - 1].inverseTimes(global_plan_tf_[idx_path]);
     double dpX = deltaPlan.getOrigin().x();
     double dpY = deltaPlan.getOrigin().y();
     iterative_dist_to_goal += hypot(dpX, dpY);
-    distance_to_goal_vector_[idx_path] = iterative_dist_to_goal;
+    distance_to_goal_vector_[idx_path - 1] = iterative_dist_to_goal;
     // compute turning radius based on trigonometric analysis
     // radius such that next pose is connected from current pose with a semi-circle
     double dpXY2 = dpY*dpY + dpX*dpX;
     if (dpXY2 < FLT_EPSILON)
     {
-      turning_radius_inv_vector_[idx_path] = std::numeric_limits<double>::infinity();
+      turning_radius_inv_vector_[idx_path - 1] = std::numeric_limits<double>::infinity();
     }
     else
     {
-      //  0.5*dpY*( 1 + dpX*dpX/(dpY*dPY) );
-      // turning_radius_vector[idx_path] = 0.5*(1/dpY)*( dpY*dpY + dpX*dpX );
-      turning_radius_inv_vector_[idx_path] = 2*dpY/dpXY2;
+      turning_radius_inv_vector_[idx_path - 1] = 2*dpY/dpXY2;
     }
-    ROS_DEBUG("turning_radius_inv_vector[%d] = %f", idx_path, turning_radius_inv_vector_[idx_path]);
+    ROS_DEBUG("turning_radius_inv_vector[%zu] = %f", idx_path - 1, turning_radius_inv_vector_[idx_path - 1]);
   }
 
   // Set initial velocity
@@ -354,9 +352,9 @@ tf2::Transform Controller::findPositionOnPlan(const geometry_msgs::Transform cur
   }
 
   // Then look backwards
-  for (int idx_path = controller_state_ptr->current_global_plan_index - 1; idx_path >= 0; idx_path--)
+  for (auto idx_path = controller_state_ptr->current_global_plan_index; idx_path > 0; --idx_path)
   {
-    error = current_tf2.inverseTimes(global_plan_tf_[idx_path]);
+    error = current_tf2.inverseTimes(global_plan_tf_[idx_path - 1]);
     // Calculate 3D distance, since current_tf2 might have significant z-offset and roll/pitch values w.r.t. path-pose
     // When not doing this, we're brutely projecting in robot's frame and might snap to another segment!
     distance_to_path = hypot(error.getOrigin().x(), error.getOrigin().y(), error.getOrigin().z());
@@ -364,7 +362,7 @@ tf2::Transform Controller::findPositionOnPlan(const geometry_msgs::Transform cur
     if (distance_to_path < minimum_distance_to_path)
     {
       minimum_distance_to_path = distance_to_path;
-      controller_state_ptr->current_global_plan_index = idx_path;
+      controller_state_ptr->current_global_plan_index = idx_path - 1;
     }
     else
     {

--- a/src/controller.cpp
+++ b/src/controller.cpp
@@ -185,36 +185,38 @@ void Controller::setPlan(geometry_msgs::Transform current_tf, geometry_msgs::Twi
   tf2::Transform deltaPlan;
   // We define segment0 to be the segment connecting pose0 and pose1.
   // Hence, when picking the starting path's pose, we mean to start at the segment connecting that and the next pose.
-  for (auto idx_path = global_plan_tf_.size() - 1; idx_path > 0; --idx_path)
+  for (int idx_path = static_cast<int>(global_plan_tf_.size() - 2); idx_path >= 0; --idx_path)
   {
     /* Get distance to segment to determine if this is the segment to start at */
-    dist_to_segment = distToSegmentSquared(current_tf2, global_plan_tf_[idx_path - 1], global_plan_tf_[idx_path]);
+    dist_to_segment = distToSegmentSquared(current_tf2, global_plan_tf_[idx_path], global_plan_tf_[idx_path + 1]);
     // Calculate 3D distance, since current_tf2 might have significant z-offset and roll/pitch values w.r.t. path-pose
     // When not doing this, we're brutely projecting in robot's frame and might snap to another segment!
     if (dist_to_segment < minimum_distance_to_path)
     {
       minimum_distance_to_path = dist_to_segment;
-      controller_state_.current_global_plan_index = idx_path - 1;
+      controller_state_.current_global_plan_index = idx_path;
     }
 
     /* Create distance and turning radius vectors once for usage later */
-    deltaPlan = global_plan_tf_[idx_path - 1].inverseTimes(global_plan_tf_[idx_path]);
+    deltaPlan = global_plan_tf_[idx_path].inverseTimes(global_plan_tf_[idx_path + 1]);
     double dpX = deltaPlan.getOrigin().x();
     double dpY = deltaPlan.getOrigin().y();
     iterative_dist_to_goal += hypot(dpX, dpY);
-    distance_to_goal_vector_[idx_path - 1] = iterative_dist_to_goal;
+    distance_to_goal_vector_[idx_path] = iterative_dist_to_goal;
     // compute turning radius based on trigonometric analysis
     // radius such that next pose is connected from current pose with a semi-circle
     double dpXY2 = dpY*dpY + dpX*dpX;
     if (dpXY2 < FLT_EPSILON)
     {
-      turning_radius_inv_vector_[idx_path - 1] = std::numeric_limits<double>::infinity();
+      turning_radius_inv_vector_[idx_path] = std::numeric_limits<double>::infinity();
     }
     else
     {
-      turning_radius_inv_vector_[idx_path - 1] = 2*dpY/dpXY2;
+      //  0.5*dpY*( 1 + dpX*dpX/(dpY*dPY) );
+      // turning_radius_vector[idx_path] = 0.5*(1/dpY)*( dpY*dpY + dpX*dpX );
+      turning_radius_inv_vector_[idx_path] = 2*dpY/dpXY2;
     }
-    ROS_DEBUG("turning_radius_inv_vector[%zu] = %f", idx_path - 1, turning_radius_inv_vector_[idx_path - 1]);
+    ROS_DEBUG("turning_radius_inv_vector[%d] = %f", idx_path, turning_radius_inv_vector_[idx_path]);
   }
 
   // Set initial velocity


### PR DESCRIPTION
Fixed signed/unsigned conversion warning from clang-tidy.

`warning: narrowing conversion from 'unsigned long' to signed type 'int' is implementation-defined [bugprone-narrowing-conversions]`

Ideally the loops should later be refactored further into algorithm calls or range based for loops.