### PR TITLE
Added FifoArray abstraction.

### DIFF
--- a/include/path_tracking_pid/controller.hpp
+++ b/include/path_tracking_pid/controller.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <path_tracking_pid/details/fifo_array.hpp>
 
 #include <array>
 #include <vector>
@@ -39,14 +40,14 @@ struct ControllerState
   double tracking_error_lat = 0.0;
   double tracking_error_ang = 0.0;
   // Errors with little history
-  std::array<double, 3> error_lat = {0.0, 0.0, 0.0};
-  std::array<double, 3> filtered_error_lat = {0.0, 0.0, 0.0};
-  std::array<double, 3> error_deriv_lat = {0.0, 0.0, 0.0};
-  std::array<double, 3> filtered_error_deriv_lat = {0.0, 0.0, 0.0};
-  std::array<double, 3> error_ang = {0.0, 0.0, 0.0};
-  std::array<double, 3> filtered_error_ang = {0.0, 0.0, 0.0};
-  std::array<double, 3> error_deriv_ang = {0.0, 0.0, 0.0};
-  std::array<double, 3> filtered_error_deriv_ang = {0.0, 0.0, 0.0};
+  details::FifoArray<double, 3> error_lat;
+  details::FifoArray<double, 3> filtered_error_lat;
+  details::FifoArray<double, 3> error_deriv_lat;
+  details::FifoArray<double, 3> filtered_error_deriv_lat;
+  details::FifoArray<double, 3> error_ang;
+  details::FifoArray<double, 3> filtered_error_ang;
+  details::FifoArray<double, 3> error_deriv_ang;
+  details::FifoArray<double, 3> filtered_error_deriv_ang;
 };
 
 class Controller : private boost::noncopyable

--- a/include/path_tracking_pid/details/fifo_array.hpp
+++ b/include/path_tracking_pid/details/fifo_array.hpp
@@ -1,0 +1,46 @@
+#pragma once
+
+#include <algorithm>
+#include <array>
+
+namespace path_tracking_pid::details
+{
+
+// Fixed-size array-like FIFO buffer. All elements are value initialized upon construction.
+template <typename value_type, std::size_t size>
+class FifoArray
+{
+public:
+  // Pushes the given value to the front of the buffer (index = 0). All elements already in the buffer are moved
+  // towards the end of the buffer (index = size - 1). The last element is removed from the buffer.
+  constexpr void push(const value_type& value)
+  {
+    std::copy_backward(data_.begin(), std::prev(data_.end()), data_.end());
+    data_[0] = value;
+  }
+
+  // Value initializes all elements in the buffer.
+  constexpr void reset()
+  {
+    data_ = {};
+  }
+
+  // Read-only access to the element at the given index.
+  constexpr const value_type& operator[](std::size_t index) const
+  {
+    return data_[index];
+  }
+
+  // Read-only access to the element at the given index (with compile-time range check).
+  template <std::size_t index>
+  constexpr const value_type& at() const
+  {
+    static_assert(index < size);
+    return data_[index];
+  }
+
+private:
+  std::array<value_type, size> data_{};
+};
+
+}  // namespace path_tracking_pid::details


### PR DESCRIPTION
I noticed there was a lot of code duplication to keep track of error history in `ControllerState`. I have 3 PRs lined up to address this. This one is the first.

Added a FIFO array abstraction.

Please note (and check) the changed offsets for the filtered errors. The old code already had moved all entries in that buffer when it calculated the new value. The new code does not so it needs different offsets.