### PR TITLE
Added derivative filtered error tracker abstraction.

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,12 @@
+Checks: 'boost-*,
+         bugprone-*,
+         cert-*,-cert-err58-cpp,
+         clang-*,-clang-analyzer-core.uninitialized.Assign,
+         concurrency-*,
+         cppcoreguidelines-*,-cppcoreguidelines-pro-type-vararg,-cppcoreguidelines-pro-bounds-array-to-pointer-decay,-cppcoreguidelines-avoid-magic-numbers,
+         misc-*,
+         modernize-*,-modernize-use-trailing-return-type,-modernize-use-nodiscard,
+         performance-*,
+         portability-*,
+         readability-*,-readability-magic-numbers'
+FormatStyle: file

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -65,6 +65,7 @@ add_library(${PROJECT_NAME}
   src/${PROJECT_NAME}_local_planner.cpp
   src/controller.cpp
   src/visualization.cpp
+  src/details/filtered_error_tracker.cpp
 )
 add_dependencies(${PROJECT_NAME} ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS} ${PROJECT_NAME}_gencfg)
 target_link_libraries(${PROJECT_NAME} ${catkin_LIBRARIES})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -66,6 +66,7 @@ add_library(${PROJECT_NAME}
   src/controller.cpp
   src/visualization.cpp
   src/details/filtered_error_tracker.cpp
+  src/details/derivative_filtered_error_tracker.cpp
 )
 add_dependencies(${PROJECT_NAME} ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS} ${PROJECT_NAME}_gencfg)
 target_link_libraries(${PROJECT_NAME} ${catkin_LIBRARIES})

--- a/include/path_tracking_pid/controller.hpp
+++ b/include/path_tracking_pid/controller.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <path_tracking_pid/details/fifo_array.hpp>
 
 #include <array>
 #include <vector>
@@ -39,14 +40,14 @@ struct ControllerState
   double tracking_error_lat = 0.0;
   double tracking_error_ang = 0.0;
   // Errors with little history
-  std::array<double, 3> error_lat = {0.0, 0.0, 0.0};
-  std::array<double, 3> filtered_error_lat = {0.0, 0.0, 0.0};
-  std::array<double, 3> error_deriv_lat = {0.0, 0.0, 0.0};
-  std::array<double, 3> filtered_error_deriv_lat = {0.0, 0.0, 0.0};
-  std::array<double, 3> error_ang = {0.0, 0.0, 0.0};
-  std::array<double, 3> filtered_error_ang = {0.0, 0.0, 0.0};
-  std::array<double, 3> error_deriv_ang = {0.0, 0.0, 0.0};
-  std::array<double, 3> filtered_error_deriv_ang = {0.0, 0.0, 0.0};
+  details::FifoArray<double, 3> error_lat;
+  details::FifoArray<double, 3> filtered_error_lat;
+  details::FifoArray<double, 3> error_deriv_lat;
+  details::FifoArray<double, 3> filtered_error_deriv_lat;
+  details::FifoArray<double, 3> error_ang;
+  details::FifoArray<double, 3> filtered_error_ang;
+  details::FifoArray<double, 3> error_deriv_ang;
+  details::FifoArray<double, 3> filtered_error_deriv_ang;
 };
 
 class Controller : private boost::noncopyable

--- a/include/path_tracking_pid/controller.hpp
+++ b/include/path_tracking_pid/controller.hpp
@@ -105,7 +105,7 @@ public:
   tf2::Transform findPositionOnPlan(const geometry_msgs::Transform current_tf,
                                     ControllerState* controller_state_ptr)
   {
-    size_t path_pose_idx;
+    size_t path_pose_idx = 0;
     return findPositionOnPlan(current_tf, controller_state_ptr, path_pose_idx);
   }
 
@@ -213,8 +213,8 @@ private:
   double distToSegmentSquared(const tf2::Transform& pose_p, const tf2::Transform& pose_v, const tf2::Transform& pose_w)
   {
     tf2::Transform dummy_tf;
-    double dummy_double;
-    double result;
+    double dummy_double = 0;
+    double result = 0;
     distToSegmentSquared(pose_p,pose_v, pose_w, dummy_tf, result, dummy_double);
     return result;
   }

--- a/include/path_tracking_pid/controller.hpp
+++ b/include/path_tracking_pid/controller.hpp
@@ -1,7 +1,7 @@
 #pragma once
 
 #include <path_tracking_pid/details/fifo_array.hpp>
-#include <path_tracking_pid/details/filtered_error_tracker.hpp>
+#include <path_tracking_pid/details/derivative_filtered_error_tracker.hpp>
 
 #include <array>
 #include <vector>
@@ -41,10 +41,8 @@ struct ControllerState
   double tracking_error_lat = 0.0;
   double tracking_error_ang = 0.0;
   // Errors with little history
-  details::FilteredErrorTracker error_lat;
-  details::FilteredErrorTracker error_deriv_lat;
-  details::FilteredErrorTracker error_ang;
-  details::FilteredErrorTracker error_deriv_ang;
+  details::DerivativeFilteredErrorTracker error_lat;
+  details::DerivativeFilteredErrorTracker error_ang;
 };
 
 class Controller : private boost::noncopyable

--- a/include/path_tracking_pid/controller.hpp
+++ b/include/path_tracking_pid/controller.hpp
@@ -98,11 +98,10 @@ public:
    * @return tf of found position on plan
    * @return index of current path-pose if requested
    */
-  tf2::Transform findPositionOnPlan(const geometry_msgs::Transform current_tf,
-                                    ControllerState* controller_state_ptr,
-                                    size_t &path_pose_idx);
+  tf2::Transform findPositionOnPlan(geometry_msgs::Transform current_tf, ControllerState* controller_state_ptr,
+                                    size_t& path_pose_idx);
   // Overloaded function definition for users that don't require the segment index
-  tf2::Transform findPositionOnPlan(const geometry_msgs::Transform current_tf,
+  tf2::Transform findPositionOnPlan(geometry_msgs::Transform current_tf,
                                     ControllerState* controller_state_ptr)
   {
     size_t path_pose_idx = 0;
@@ -120,12 +119,9 @@ public:
    * @return progress Progress along the path [0,1]
    * @return pid_debug Variable with information to debug the controller
    */
-  geometry_msgs::Twist update(const double target_x_vel,
-                              const double target_end_x_vel,
-                              const geometry_msgs::Transform current_tf,
-                              const geometry_msgs::Twist odom_twist,
-                              const ros::Duration dt,
-                              double* eda, double* progress, path_tracking_pid::PidDebug* pid_debug);
+  geometry_msgs::Twist update(double target_x_vel, double target_end_x_vel, geometry_msgs::Transform current_tf,
+                              geometry_msgs::Twist odom_twist, ros::Duration dt, double* eda, double* progress,
+                              path_tracking_pid::PidDebug* pid_debug);
 
   /**
    * Run one iteration of a PID controller with velocity limits applied
@@ -137,10 +133,9 @@ public:
    * @return progress Progress along the path [0,1]
    * @return pid_debug Variable with information to debug the controller
    */
-  geometry_msgs::Twist update_with_limits(const geometry_msgs::Transform current_tf,
-                                          const geometry_msgs::Twist odom_twist,
-                                          const ros::Duration dt,
-                                          double* eda, double* progress, path_tracking_pid::PidDebug* pid_debug);
+  geometry_msgs::Twist update_with_limits(geometry_msgs::Transform current_tf, geometry_msgs::Twist odom_twist,
+                                          ros::Duration dt, double* eda, double* progress,
+                                          path_tracking_pid::PidDebug* pid_debug);
 
   /**
    * Perform prediction steps on the lateral error and return a reduced velocity that stays within bounds
@@ -148,8 +143,7 @@ public:
    * @param odom_twist Robot odometry
    * @return Velocity command
    */
-  double mpc_based_max_vel(const double target_x_vel, geometry_msgs::Transform current_tf,
-                           geometry_msgs::Twist odom_twist);
+  double mpc_based_max_vel(double target_x_vel, geometry_msgs::Transform current_tf, geometry_msgs::Twist odom_twist);
 
   /**
    * Set dynamic parameters for the PID controller
@@ -204,13 +198,13 @@ public:
   double getVelMaxObstacle() const;
 
 private:
-  double distSquared(const tf2::Transform& pose_v, const tf2::Transform& pose_w) const;
-  double distSquared(const geometry_msgs::Pose& pose_v, const geometry_msgs::Pose& pose_w) const;
+  static double distSquared(const tf2::Transform& pose_v, const tf2::Transform& pose_w);
+  static double distSquared(const geometry_msgs::Pose& pose_v, const geometry_msgs::Pose& pose_w);
   void distToSegmentSquared(const tf2::Transform& pose_p, const tf2::Transform& pose_v, const tf2::Transform& pose_w,
-                            tf2::Transform& pose_projection, double& distance_to_p, double& distance_to_w);
+                            tf2::Transform& pose_projection, double& distance_to_p, double& distance_to_w) const;
 
   // Overloaded function for callers that don't need the additional results
-  double distToSegmentSquared(const tf2::Transform& pose_p, const tf2::Transform& pose_v, const tf2::Transform& pose_w)
+  double distToSegmentSquared(const tf2::Transform& pose_p, const tf2::Transform& pose_v, const tf2::Transform& pose_w) const
   {
     tf2::Transform dummy_tf;
     double dummy_double = 0;
@@ -224,7 +218,7 @@ private:
   /**
    * Output some debug information about the current parameters
    */
-  void printParameters();
+  void printParameters() const;
 
   path_tracking_pid::PidConfig local_config_;
   ControllerState controller_state_;

--- a/include/path_tracking_pid/controller.hpp
+++ b/include/path_tracking_pid/controller.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <path_tracking_pid/details/fifo_array.hpp>
+#include <path_tracking_pid/details/filtered_error_tracker.hpp>
 
 #include <array>
 #include <vector>
@@ -40,14 +41,10 @@ struct ControllerState
   double tracking_error_lat = 0.0;
   double tracking_error_ang = 0.0;
   // Errors with little history
-  details::FifoArray<double, 3> error_lat;
-  details::FifoArray<double, 3> filtered_error_lat;
-  details::FifoArray<double, 3> error_deriv_lat;
-  details::FifoArray<double, 3> filtered_error_deriv_lat;
-  details::FifoArray<double, 3> error_ang;
-  details::FifoArray<double, 3> filtered_error_ang;
-  details::FifoArray<double, 3> error_deriv_ang;
-  details::FifoArray<double, 3> filtered_error_deriv_ang;
+  details::FilteredErrorTracker error_lat;
+  details::FilteredErrorTracker error_deriv_lat;
+  details::FilteredErrorTracker error_ang;
+  details::FilteredErrorTracker error_deriv_ang;
 };
 
 class Controller : private boost::noncopyable

--- a/include/path_tracking_pid/details/derivative_filtered_error_tracker.hpp
+++ b/include/path_tracking_pid/details/derivative_filtered_error_tracker.hpp
@@ -1,0 +1,40 @@
+#pragma once
+
+#include <path_tracking_pid/details/filtered_error_tracker.hpp>
+
+#include <chrono>
+
+namespace path_tracking_pid::details
+{
+
+// Error tracker for the last 3 error, derivative error and their filtered values.
+class DerivativeFilteredErrorTracker
+{
+public:
+  // Pushes the given value to the errors FIFO buffer. A corresponding filtered error value is calculated and pushed
+  // to the filtered errors FIFO buffer. The given time delta is used to calculate the derivative error, which is
+  // pushed to the derivative errors FIFO buffer. A corresponding filtered derivative error value is calculated and
+  // pushed to the filtered derivative errors FIFO buffer.
+  void push(double value, std::chrono::duration<double> td);
+
+  // Resets all FIFO buffers.
+  void reset();
+
+  // Retrieves the current error value.
+  double current_error() const;
+
+  // Retrieves the current filtered error value.
+  double current_filtered_error() const;
+
+  // Retrieves the current derivative error value.
+  double current_derivative_error() const;
+
+  // Retrieves the current filtered derivative error value.
+  double current_filtered_derivative_error() const;
+
+private:
+  FilteredErrorTracker errors_;
+  FilteredErrorTracker derivative_errors_;
+};
+
+}  // namespace path_tracking_pid::details

--- a/include/path_tracking_pid/details/fifo_array.hpp
+++ b/include/path_tracking_pid/details/fifo_array.hpp
@@ -1,0 +1,46 @@
+#pragma once
+
+#include <algorithm>
+#include <array>
+
+namespace path_tracking_pid::details
+{
+
+// Fixed-size array-like FIFO buffer. All elements are value initialized upon construction.
+template <typename value_type, std::size_t size>
+class FifoArray
+{
+public:
+  // Pushes the given value to the front of the buffer (index = 0). All elements already in the buffer are moved
+  // towards the end of the buffer (index = size - 1). The last element is removed from the buffer.
+  constexpr void push(const value_type& value)
+  {
+    std::copy_backward(data_.begin(), std::prev(data_.end()), data_.end());
+    data_[0] = value;
+  }
+
+  // Value initializes all elements in the buffer.
+  constexpr void reset()
+  {
+    data_ = {};
+  }
+
+  // Read-only access to the element at the given index.
+  constexpr const value_type& operator[](std::size_t index) const
+  {
+    return data_[index];
+  }
+
+  // Read-only access to the element at the given index (with compile-time range check).
+  template <std::size_t index>
+  constexpr const value_type& at() const
+  {
+    static_assert(index < size);
+    return data_[index];
+  }
+
+private:
+  std::array<value_type, size> data_{};
+};
+
+}  // namespace path_tracking_pid::details

--- a/include/path_tracking_pid/details/filtered_error_tracker.hpp
+++ b/include/path_tracking_pid/details/filtered_error_tracker.hpp
@@ -1,0 +1,30 @@
+#pragma once
+
+#include <path_tracking_pid/details/fifo_array.hpp>
+
+namespace path_tracking_pid::details
+{
+
+// Error tracker for the last 3 error and filtered error values.
+class FilteredErrorTracker
+{
+public:
+  // Pushes the given value to the errors FIFO buffer. A corresponding filtered error value is calculated and pushed
+  // to the filtered errors FIFO buffer.
+  void push(double value);
+
+  // Resets both errors and filtered errors FIFO buffers.
+  void reset();
+
+  // Read-only access to the errors FIFO buffer.
+  const FifoArray<double, 3>& errors() const;
+
+  // Read-only access to the filtered errors FIFO buffer.
+  const FifoArray<double, 3>& filtered_errors() const;
+
+private:
+  FifoArray<double, 3> errors_;
+  FifoArray<double, 3> filtered_errors_;
+};
+
+}  // namespace path_tracking_pid::details

--- a/include/path_tracking_pid/path_tracking_pid_local_planner.hpp
+++ b/include/path_tracking_pid/path_tracking_pid_local_planner.hpp
@@ -33,7 +33,7 @@ class TrackingPidLocalPlanner : public nav_core::BaseLocalPlanner, public mbf_co
 private:
   typedef boost::geometry::model::ring<geometry_msgs::Point> polygon_t;
 
-  inline polygon_t union_(polygon_t polygon1, polygon_t polygon2)
+  static inline polygon_t union_(const polygon_t& polygon1, const polygon_t& polygon2)
   {
     std::vector<polygon_t> output_vec;
     boost::geometry::union_(polygon1, polygon2, output_vec);

--- a/include/path_tracking_pid/visualization.hpp
+++ b/include/path_tracking_pid/visualization.hpp
@@ -19,10 +19,10 @@ public:
 
 private:
   void publishSphere(
-    const std_msgs::Header & header, std::string ns, int id, const tf2::Transform & pose,
+    const std_msgs::Header & header, const std::string& ns, int id, const tf2::Transform & pose,
     const std_msgs::ColorRGBA & color);
   void publishSphere(
-    const std_msgs::Header & header, std::string ns, int id, geometry_msgs::Pose pose,
+    const std_msgs::Header & header, const std::string& ns, int id, geometry_msgs::Pose pose,
     const std_msgs::ColorRGBA & color);
 
   ros::Publisher marker_pub_;

--- a/src/controller.cpp
+++ b/src/controller.cpp
@@ -990,10 +990,9 @@ double Controller::mpc_based_max_vel(double target_x_vel, geometry_msgs::Transfo
       }
 
       // Increase speed
-      double prev_save = new_nominal_x_vel;
-      new_nominal_x_vel = copysign(1.0, new_nominal_x_vel)
-                                  * abs(target_x_vel_prev - new_nominal_x_vel) / 2 + new_nominal_x_vel;
-      target_x_vel_prev = prev_save;
+      target_x_vel_prev = std::exchange(
+          new_nominal_x_vel,
+          copysign(1.0, new_nominal_x_vel) * abs(target_x_vel_prev - new_nominal_x_vel) / 2 + new_nominal_x_vel);
 
       // Reset variables
       controller_state_ = controller_state_saved;
@@ -1008,10 +1007,9 @@ double Controller::mpc_based_max_vel(double target_x_vel, geometry_msgs::Transfo
       mpc_vel_optimization_iter += 1;
 
       // Lower speed
-      double prev_save = new_nominal_x_vel;
-      new_nominal_x_vel = -copysign(1.0, new_nominal_x_vel)
-                                  * abs(target_x_vel_prev - new_nominal_x_vel) / 2 + new_nominal_x_vel;
-      target_x_vel_prev = prev_save;
+      target_x_vel_prev = std::exchange(
+          new_nominal_x_vel,
+          -copysign(1.0, new_nominal_x_vel) * abs(target_x_vel_prev - new_nominal_x_vel) / 2 + new_nominal_x_vel);
 
       // Reset variables
       controller_state_ = controller_state_saved;

--- a/src/controller.cpp
+++ b/src/controller.cpp
@@ -489,13 +489,8 @@ geometry_msgs::Twist Controller::update(double target_x_vel,
     ROS_WARN("All three gains (Kp, Ki, Kd) should have the same sign for stability.");
   }
 
-  controller_state_.error_lat.at(2) = controller_state_.error_lat.at(1);
-  controller_state_.error_lat.at(1) = controller_state_.error_lat.at(0);
-  controller_state_.error_lat.at(0) = error.getOrigin().y();  // Current error goes to slot 0
-  controller_state_.error_ang.at(2) = controller_state_.error_ang.at(1);
-  controller_state_.error_ang.at(1) = controller_state_.error_ang.at(0);
-  controller_state_.error_ang.at(0) =
-      angles::normalize_angle(tf2::getYaw(error.getRotation()));  // Current error goes to slot 0
+  controller_state_.error_lat.push(error.getOrigin().y());
+  controller_state_.error_ang.push(angles::normalize_angle(tf2::getYaw(error.getRotation())));
 
   // tracking error for diagnostic purposes
   // Transform current pose into local-path-frame to get tracked-frame-error
@@ -514,67 +509,55 @@ geometry_msgs::Twist Controller::update(double target_x_vel,
 
   // trackin_error here represents the error between tracked link and position on plan
   controller_state_.tracking_error_lat = current_tracking_err.y();
-  controller_state_.tracking_error_ang = controller_state_.error_ang.at(0);
+  controller_state_.tracking_error_ang = controller_state_.error_ang.at<0>();
 
   // integrate the error
-  controller_state_.error_integral_lat += controller_state_.error_lat.at(0) * dt.toSec();
-  controller_state_.error_integral_ang += controller_state_.error_ang.at(0) * dt.toSec();
+  controller_state_.error_integral_lat += controller_state_.error_lat.at<0>() * dt.toSec();
+  controller_state_.error_integral_ang += controller_state_.error_ang.at<0>() * dt.toSec();
 
   // Apply windup limit to limit the size of the integral term
   controller_state_.error_integral_lat = std::clamp(controller_state_.error_integral_lat, -windup_limit, windup_limit);
   controller_state_.error_integral_ang = std::clamp(controller_state_.error_integral_ang, -windup_limit, windup_limit);
 
-  controller_state_.filtered_error_lat.at(2) = controller_state_.filtered_error_lat.at(1);
-  controller_state_.filtered_error_lat.at(1) = controller_state_.filtered_error_lat.at(0);
-  controller_state_.filtered_error_lat.at(0) =
+  controller_state_.filtered_error_lat.push(
       (1 / (1 + c_lat * c_lat + M_SQRT2 * c_lat)) *
-      (controller_state_.error_lat.at(2) + 2 * controller_state_.error_lat.at(1) + controller_state_.error_lat.at(0) -
-       (c_lat * c_lat - M_SQRT2 * c_lat + 1) * controller_state_.filtered_error_lat.at(2) -
-       (-2 * c_lat * c_lat + 2) * controller_state_.filtered_error_lat.at(1));
+      (controller_state_.error_lat.at<2>() + 2 * controller_state_.error_lat.at<1>() + controller_state_.error_lat.at<0>() -
+       (c_lat * c_lat - M_SQRT2 * c_lat + 1) * controller_state_.filtered_error_lat.at<1>() -
+       (-2 * c_lat * c_lat + 2) * controller_state_.filtered_error_lat.at<0>()));
 
-  controller_state_.filtered_error_ang.at(2) = controller_state_.filtered_error_ang.at(1);
-  controller_state_.filtered_error_ang.at(1) = controller_state_.filtered_error_ang.at(0);
-  controller_state_.filtered_error_ang.at(0) =
+  controller_state_.filtered_error_ang.push(
       (1 / (1 + c_ang * c_ang + M_SQRT2 * c_ang)) *
-      (controller_state_.error_ang.at(2) + 2 * controller_state_.error_ang.at(1) + controller_state_.error_ang.at(0) -
-       (c_ang * c_ang - M_SQRT2 * c_ang + 1) * controller_state_.filtered_error_ang.at(2) -
-       (-2 * c_ang * c_ang + 2) * controller_state_.filtered_error_ang.at(1));
+      (controller_state_.error_ang.at<2>() + 2 * controller_state_.error_ang.at<1>() + controller_state_.error_ang.at<0>() -
+       (c_ang * c_ang - M_SQRT2 * c_ang + 1) * controller_state_.filtered_error_ang.at<1>() -
+       (-2 * c_ang * c_ang + 2) * controller_state_.filtered_error_ang.at<0>()));
 
   // Take derivative of error, first the raw unfiltered data:
-  controller_state_.error_deriv_lat.at(2) = controller_state_.error_deriv_lat.at(1);
-  controller_state_.error_deriv_lat.at(1) = controller_state_.error_deriv_lat.at(0);
-  controller_state_.error_deriv_lat.at(0) =
-      (controller_state_.error_lat.at(0) - controller_state_.error_lat.at(1)) / dt.toSec();
-  controller_state_.filtered_error_deriv_lat.at(2) = controller_state_.filtered_error_deriv_lat.at(1);
-  controller_state_.filtered_error_deriv_lat.at(1) = controller_state_.filtered_error_deriv_lat.at(0);
-  controller_state_.filtered_error_deriv_lat.at(0) =
+  controller_state_.error_deriv_lat.push(
+    (controller_state_.error_lat.at<0>() - controller_state_.error_lat.at<1>()) / dt.toSec());
+  controller_state_.filtered_error_deriv_lat.push(
       (1 / (1 + c_lat * c_lat + M_SQRT2 * c_lat)) *
-      (controller_state_.error_deriv_lat.at(2) + 2 * controller_state_.error_deriv_lat.at(1) +
-       controller_state_.error_deriv_lat.at(0) -
-       (c_lat * c_lat - M_SQRT2 * c_lat + 1) * controller_state_.filtered_error_deriv_lat.at(2) -
-       (-2 * c_lat * c_lat + 2) * controller_state_.filtered_error_deriv_lat.at(1));
+      (controller_state_.error_deriv_lat.at<2>() + 2 * controller_state_.error_deriv_lat.at<1>() +
+       controller_state_.error_deriv_lat.at<0>() -
+       (c_lat * c_lat - M_SQRT2 * c_lat + 1) * controller_state_.filtered_error_deriv_lat.at<1>() -
+       (-2 * c_lat * c_lat + 2) * controller_state_.filtered_error_deriv_lat.at<0>()));
 
-  controller_state_.error_deriv_ang.at(2) = controller_state_.error_deriv_ang.at(1);
-  controller_state_.error_deriv_ang.at(1) = controller_state_.error_deriv_ang.at(0);
-  controller_state_.error_deriv_ang.at(0) =
-      (controller_state_.error_ang.at(0) - controller_state_.error_ang.at(1)) / dt.toSec();
-  controller_state_.filtered_error_deriv_ang.at(2) = controller_state_.filtered_error_deriv_ang.at(1);
-  controller_state_.filtered_error_deriv_ang.at(1) = controller_state_.filtered_error_deriv_ang.at(0);
-  controller_state_.filtered_error_deriv_ang.at(0) =
+  controller_state_.error_deriv_ang.push(
+    (controller_state_.error_ang.at<0>() - controller_state_.error_ang.at<1>()) / dt.toSec());
+  controller_state_.filtered_error_deriv_ang.push(
       (1 / (1 + c_ang * c_ang + M_SQRT2 * c_ang)) *
-      (controller_state_.error_deriv_ang.at(2) + 2 * controller_state_.error_deriv_ang.at(1) +
-       controller_state_.error_deriv_ang.at(0) -
-       (c_ang * c_ang - M_SQRT2 * c_ang + 1) * controller_state_.filtered_error_deriv_ang.at(2) -
-       (-2 * c_ang * c_ang + 2) * controller_state_.filtered_error_deriv_ang.at(1));
+      (controller_state_.error_deriv_ang.at<2>() + 2 * controller_state_.error_deriv_ang.at<1>() +
+       controller_state_.error_deriv_ang.at<0>() -
+       (c_ang * c_ang - M_SQRT2 * c_ang + 1) * controller_state_.filtered_error_deriv_ang.at<1>() -
+       (-2 * c_ang * c_ang + 2) * controller_state_.filtered_error_deriv_ang.at<0>()));
 
   // calculate the control effort
-  const auto proportional_lat = Kp_lat_ * controller_state_.filtered_error_lat.at(0);
+  const auto proportional_lat = Kp_lat_ * controller_state_.filtered_error_lat.at<0>();
   const auto integral_lat = Ki_lat_ * controller_state_.error_integral_lat;
-  const auto derivative_lat = Kd_lat_ * controller_state_.filtered_error_deriv_lat.at(0);
+  const auto derivative_lat = Kd_lat_ * controller_state_.filtered_error_deriv_lat.at<0>();
 
-  const auto proportional_ang = Kp_ang_ * controller_state_.filtered_error_ang.at(0);
+  const auto proportional_ang = Kp_ang_ * controller_state_.filtered_error_ang.at<0>();
   const auto integral_ang = Ki_ang_ * controller_state_.error_integral_ang;
-  const auto derivative_ang = Kd_ang_ * controller_state_.filtered_error_deriv_ang.at(0);
+  const auto derivative_ang = Kd_ang_ * controller_state_.filtered_error_deriv_ang.at<0>();
 
 
   /***** Compute forward velocity *****/
@@ -770,8 +753,8 @@ geometry_msgs::Twist Controller::update(double target_x_vel,
   // Populate debug output
   // Error topic containing the 'control' error on which the PID acts
   pid_debug->control_error.linear.x = 0.0;
-  pid_debug->control_error.linear.y = controller_state_.error_lat.at(0);
-  pid_debug->control_error.angular.z = controller_state_.error_ang.at(0);
+  pid_debug->control_error.linear.y = controller_state_.error_lat.at<0>();
+  pid_debug->control_error.angular.z = controller_state_.error_ang.at<0>();
   // Error topic containing the 'tracking' error, i.e. the real error between path and tracked link
   pid_debug->tracking_error.linear.x = 0.0;
   pid_debug->tracking_error.linear.y = controller_state_.tracking_error_lat;
@@ -978,7 +961,7 @@ double Controller::mpc_based_max_vel(double target_x_vel, geometry_msgs::Transfo
 
     // Check if robot stays within bounds for all iterations, if the new_nominal_x_vel is smaller than
     // max_target_x_vel we can increase it
-    if (mpc_fwd_iter == mpc_max_fwd_iter_ && fabs(controller_state_.error_lat.at(0)) <= mpc_max_error_lat_ &&
+    if (mpc_fwd_iter == mpc_max_fwd_iter_ && fabs(controller_state_.error_lat.at<0>()) <= mpc_max_error_lat_ &&
         fabs(new_nominal_x_vel) < abs(target_x_vel))
     {
       mpc_vel_optimization_iter += 1;
@@ -1002,7 +985,7 @@ double Controller::mpc_based_max_vel(double target_x_vel, geometry_msgs::Transfo
       mpc_fwd_iter = 0;
     }
     // If the robot gets out of bounds earlier we decrease the velocity
-    else if (abs(controller_state_.error_lat.at(0)) >= mpc_max_error_lat_)
+    else if (abs(controller_state_.error_lat.at<0>()) >= mpc_max_error_lat_)
     {
       mpc_vel_optimization_iter += 1;
 
@@ -1083,15 +1066,15 @@ void Controller::configure(path_tracking_pid::PidConfig& config)
 {
   // Erase all queues when config changes
 
-  std::fill(controller_state_.error_lat.begin(), controller_state_.error_lat.end(), 0);
-  std::fill(controller_state_.filtered_error_lat.begin(), controller_state_.filtered_error_lat.end(), 0);
-  std::fill(controller_state_.error_deriv_lat.begin(), controller_state_.error_deriv_lat.end(), 0);
-  std::fill(controller_state_.filtered_error_deriv_lat.begin(), controller_state_.filtered_error_deriv_lat.end(), 0);
+  controller_state_.error_lat.reset();
+  controller_state_.filtered_error_lat.reset();
+  controller_state_.error_deriv_lat.reset();
+  controller_state_.filtered_error_deriv_lat.reset();
 
-  std::fill(controller_state_.error_ang.begin(), controller_state_.error_ang.end(), 0);
-  std::fill(controller_state_.filtered_error_ang.begin(), controller_state_.filtered_error_ang.end(), 0);
-  std::fill(controller_state_.error_deriv_ang.begin(), controller_state_.error_deriv_ang.end(), 0);
-  std::fill(controller_state_.filtered_error_deriv_ang.begin(), controller_state_.filtered_error_deriv_ang.end(), 0);
+  controller_state_.error_ang.reset();
+  controller_state_.filtered_error_ang.reset();
+  controller_state_.error_deriv_ang.reset();
+  controller_state_.filtered_error_deriv_ang.reset();
 
   Kp_lat_ = config.Kp_lat;
   Ki_lat_ = config.Ki_lat;
@@ -1180,14 +1163,14 @@ void Controller::reset()
   controller_state_.previous_steering_x_vel = 0.0;
   controller_state_.error_integral_lat = 0.0;
   controller_state_.error_integral_ang = 0.0;
-  controller_state_.error_lat = {0.0, 0.0, 0.0};
-  controller_state_.filtered_error_lat = {0.0, 0.0, 0.0};
-  controller_state_.error_deriv_lat = {0.0, 0.0, 0.0};
-  controller_state_.filtered_error_deriv_lat = {0.0, 0.0, 0.0};
-  controller_state_.error_ang = {0.0, 0.0, 0.0};
-  controller_state_.filtered_error_ang = {0.0, 0.0, 0.0};
-  controller_state_.error_deriv_ang = {0.0, 0.0, 0.0};
-  controller_state_.filtered_error_deriv_ang = {0.0, 0.0, 0.0};
+  controller_state_.error_lat.reset();
+  controller_state_.filtered_error_lat.reset();
+  controller_state_.error_deriv_lat.reset();
+  controller_state_.filtered_error_deriv_lat.reset();
+  controller_state_.error_ang.reset();
+  controller_state_.filtered_error_ang.reset();
+  controller_state_.error_deriv_ang.reset();
+  controller_state_.filtered_error_deriv_ang.reset();
 }
 
 void Controller::setVelMaxExternal(double value)

--- a/src/controller.cpp
+++ b/src/controller.cpp
@@ -174,7 +174,7 @@ void Controller::setPlan(geometry_msgs::Transform current_tf, geometry_msgs::Twi
 
   // find closest current position to global plan
   double minimum_distance_to_path = 1e3;
-  double dist_to_segment;
+  double dist_to_segment = 0;
   double iterative_dist_to_goal = 0.0;
   distance_to_goal_vector_.clear();
   distance_to_goal_vector_.resize(global_plan_tf_.size());
@@ -328,7 +328,7 @@ tf2::Transform Controller::findPositionOnPlan(const geometry_msgs::Transform cur
 
   // find closest current position to global plan
   double minimum_distance_to_path = FLT_MAX;
-  double distance_to_path;
+  double distance_to_path = 0;
   tf2::Transform error;
 
   // We define segment0 to be the segment connecting pose0 and pose1.
@@ -379,10 +379,10 @@ tf2::Transform Controller::findPositionOnPlan(const geometry_msgs::Transform cur
 
   tf2::Transform pose_projection_ahead;
   tf2::Transform pose_projection_behind;
-  double distance2_to_line_ahead;
-  double distance2_to_line_behind;
-  double distance_to_end_line_ahead;
-  double distance_to_end_line_behind;
+  double distance2_to_line_ahead = 0;
+  double distance2_to_line_behind = 0;
+  double distance_to_end_line_ahead = 0;
+  double distance_to_end_line_behind = 0;
   if (controller_state_ptr->current_global_plan_index == 0)
   {
     distToSegmentSquared(current_tf2, global_plan_tf_[0], global_plan_tf_[1],
@@ -451,7 +451,7 @@ geometry_msgs::Twist Controller::update(const double target_x_vel,
   tf2::Quaternion cur_rot(current_tf.rotation.x, current_tf.rotation.y, current_tf.rotation.z, current_tf.rotation.w);
   current_with_carrot_.setRotation(cur_rot);
 
-  size_t path_pose_idx;
+  size_t path_pose_idx = 0;
   if (track_base_link_enabled_)
   {
     // Find closes robot position to path and then project carrot on goal
@@ -575,10 +575,10 @@ geometry_msgs::Twist Controller::update(const double target_x_vel,
 
   /***** Compute forward velocity *****/
   // Apply acceleration limits and end velocity
-  double current_target_acc;
-  double acc;
-  double t_end_phase_current;
-  double d_end_phase;
+  double current_target_acc = 0;
+  double acc = 0;
+  double t_end_phase_current = 0;
+  double d_end_phase = 0;
 
   // Compute time to reach end velocity from current velocity
   // Compute estimate overall distance during end_phase
@@ -807,7 +807,7 @@ geometry_msgs::Twist Controller::update(const double target_x_vel,
                                 control_effort_ang_;  // Take the sign of l for the lateral control effort
     output_combined.angular.z = std::clamp(output_combined.angular.z, -max_yaw_vel_, max_yaw_vel_);
     // For non-holonomic robots apply saturation based on minimum turning radius
-    double max_ang_twist_tr;
+    double max_ang_twist_tr = 0;
     if (minimum_turning_radius_ < RADIUS_EPS)
     {
       // Rotation in place is allowed
@@ -1019,7 +1019,8 @@ double Controller::mpc_based_max_vel(const double target_x_vel, geometry_msgs::T
       // Run controller
       // Output: pred_twist.[linear.x, linear.y, linear.z, angular.x, angular.y, angular.z]
       path_tracking_pid::PidDebug pid_debug_unused;
-      double eda_unused, progress_unused;
+      double eda_unused = 0;
+      double progress_unused = 0;
       pred_twist = Controller::update(new_nominal_x_vel, target_end_x_vel_, predicted_tf, pred_twist,
                                       ros::Duration(mpc_simulation_sample_time_),
                                       &eda_unused, &progress_unused, &pid_debug_unused);

--- a/src/controller.cpp
+++ b/src/controller.cpp
@@ -258,14 +258,14 @@ void Controller::setPlan(geometry_msgs::Transform current_tf, geometry_msgs::Twi
 
 // https://stackoverflow.com/questions/849211/shortest-distance-between-a-point-and-a-line-segment
 // TODO(Cesar): expand to 3 dimensions
-double Controller::distSquared(const tf2::Transform& pose_v, const tf2::Transform& pose_w) const
+double Controller::distSquared(const tf2::Transform& pose_v, const tf2::Transform& pose_w)
 {
   // Returns square distance between 2 points
   return (pose_v.getOrigin().x() - pose_w.getOrigin().x()) * (pose_v.getOrigin().x() - pose_w.getOrigin().x()) +
          (pose_v.getOrigin().y() - pose_w.getOrigin().y()) * (pose_v.getOrigin().y() - pose_w.getOrigin().y());
 }
 
-double Controller::distSquared(const geometry_msgs::Pose& pose_v, const geometry_msgs::Pose& pose_w) const
+double Controller::distSquared(const geometry_msgs::Pose& pose_v, const geometry_msgs::Pose& pose_w)
 {
   // Returns square distance between 2 points
   return (pose_v.position.x - pose_w.position.x) * (pose_v.position.x - pose_w.position.x) +
@@ -274,7 +274,7 @@ double Controller::distSquared(const geometry_msgs::Pose& pose_v, const geometry
 
 void Controller::distToSegmentSquared(
   const tf2::Transform& pose_p, const tf2::Transform& pose_v, const tf2::Transform& pose_w,
-  tf2::Transform& pose_projection, double& distance_to_p, double& distance_to_w)
+  tf2::Transform& pose_projection, double& distance_to_p, double& distance_to_w) const
 {
   double l2 = distSquared(pose_v, pose_w);
   if (l2 == 0)
@@ -312,7 +312,7 @@ void Controller::distToSegmentSquared(
   }
 }
 
-tf2::Transform Controller::findPositionOnPlan(const geometry_msgs::Transform current_tf,
+tf2::Transform Controller::findPositionOnPlan(geometry_msgs::Transform current_tf,
                                               ControllerState* controller_state_ptr,
                                               size_t &path_pose_idx)
 {
@@ -430,11 +430,11 @@ tf2::Transform Controller::findPositionOnPlan(const geometry_msgs::Transform cur
   return current_goal_local;
 }
 
-geometry_msgs::Twist Controller::update(const double target_x_vel,
-                                        const double target_end_x_vel,
-                                        const geometry_msgs::Transform current_tf,
-                                        const geometry_msgs::Twist odom_twist,
-                                        const ros::Duration dt,
+geometry_msgs::Twist Controller::update(double target_x_vel,
+                                        double target_end_x_vel,
+                                        geometry_msgs::Transform current_tf,
+                                        geometry_msgs::Twist odom_twist,
+                                        ros::Duration dt,
                                         double* eda, double* progress, path_tracking_pid::PidDebug* pid_debug)
 {
   double current_x_vel = controller_state_.current_x_vel;
@@ -480,10 +480,14 @@ geometry_msgs::Twist Controller::update(const double target_x_vel,
   //***** Feedback control *****//
   if (!((Kp_lat_ <= 0. && Ki_lat_ <= 0. && Kd_lat_ <= 0.) ||
         (Kp_lat_ >= 0. && Ki_lat_ >= 0. && Kd_lat_ >= 0.)))  // All 3 gains should have the same sign
+  {
     ROS_WARN("All three gains (Kp, Ki, Kd) should have the same sign for stability.");
+  }
   if (!((Kp_ang_ <= 0. && Ki_ang_ <= 0. && Kd_ang_ <= 0.) ||
         (Kp_ang_ >= 0. && Ki_ang_ >= 0. && Kd_ang_ >= 0.)))  // All 3 gains should have the same sign
+  {
     ROS_WARN("All three gains (Kp, Ki, Kd) should have the same sign for stability.");
+  }
 
   controller_state_.error_lat.at(2) = controller_state_.error_lat.at(1);
   controller_state_.error_lat.at(1) = controller_state_.error_lat.at(0);
@@ -575,7 +579,6 @@ geometry_msgs::Twist Controller::update(const double target_x_vel,
 
   /***** Compute forward velocity *****/
   // Apply acceleration limits and end velocity
-  double current_target_acc = 0;
   double acc = 0;
   double t_end_phase_current = 0;
   double d_end_phase = 0;
@@ -632,7 +635,7 @@ geometry_msgs::Twist Controller::update(const double target_x_vel,
   }
 
   // Determine if we need to accelerate, decelerate or maintain speed
-  current_target_acc = 0;  // Assume maintaining speed
+  double current_target_acc = 0;  // Assume maintaining speed
   if (fabs(current_target_x_vel_) <= VELOCITY_EPS)  // Zero velocity requested
   {
     if (current_x_vel > current_target_x_vel_)
@@ -728,10 +731,13 @@ geometry_msgs::Twist Controller::update(const double target_x_vel,
   control_effort_ang_ = 0.0;
 
   if (feedback_lat_enabled_)
+  {
     control_effort_lat_ = proportional_lat + integral_lat + derivative_lat;
+  }
   if (feedback_ang_enabled_)
+  {
     control_effort_ang_ = proportional_ang + integral_ang + derivative_ang;
-
+  }
 
   //***** Feedforward control *****//
   if (feedforward_lat_enabled_)
@@ -740,7 +746,9 @@ geometry_msgs::Twist Controller::update(const double target_x_vel,
     control_effort_lat_ = control_effort_lat_ + feedforward_lat_;
   }
   else
+  {
     feedforward_lat_ = 0.0;
+  }
 
   if (feedforward_ang_enabled_)
   {
@@ -751,8 +759,9 @@ geometry_msgs::Twist Controller::update(const double target_x_vel,
     control_effort_ang_ = control_effort_ang_ + feedforward_ang_;
   }
   else
+  {
     feedforward_ang_ = 0.0;
-
+  }
 
   // Apply saturation limits
   control_effort_lat_ = std::clamp(control_effort_lat_, lat_lower_limit, lat_upper_limit);
@@ -836,9 +845,13 @@ geometry_msgs::Twist Controller::update(const double target_x_vel,
     {
       steering_cmd.speed = - steering_cmd.speed;
       if (steering_cmd.steering_angle > 0)
+      {
         steering_cmd.steering_angle = steering_cmd.steering_angle - M_PI;
+      }
       else
+      {
         steering_cmd.steering_angle = steering_cmd.steering_angle + M_PI;
+      }
     }
     // Apply limits to steering commands
     steering_cmd.steering_angle = std::clamp(steering_cmd.steering_angle,
@@ -885,9 +898,9 @@ geometry_msgs::Twist Controller::update(const double target_x_vel,
   return output_combined;
 }
 
-geometry_msgs::Twist Controller::update_with_limits(const geometry_msgs::Transform current_tf,
-                                                    const geometry_msgs::Twist odom_twist,
-                                                    const ros::Duration dt,
+geometry_msgs::Twist Controller::update_with_limits(geometry_msgs::Transform current_tf,
+                                                    geometry_msgs::Twist odom_twist,
+                                                    ros::Duration dt,
                                                     double* eda, double* progress,
                                                     path_tracking_pid::PidDebug* pid_debug)
 {
@@ -938,7 +951,7 @@ geometry_msgs::Twist Controller::update_with_limits(const geometry_msgs::Transfo
 
 // output updated velocity command: (Current position, current measured velocity, closest point index, estimated
 // duration of arrival, debug info)
-double Controller::mpc_based_max_vel(const double target_x_vel, geometry_msgs::Transform current_tf,
+double Controller::mpc_based_max_vel(double target_x_vel, geometry_msgs::Transform current_tf,
                                      geometry_msgs::Twist odom_twist)
 {
   // Temporary save global data
@@ -957,7 +970,6 @@ double Controller::mpc_based_max_vel(const double target_x_vel, geometry_msgs::T
   geometry_msgs::Twist pred_twist = odom_twist;
 
   double new_nominal_x_vel = target_x_vel;  // Start off from the current velocity
-  double mpc_vel_limit = new_nominal_x_vel;
 
   // Loop MPC
   while (mpc_fwd_iter < mpc_max_fwd_iter_ && mpc_vel_optimization_iter <= mpc_max_vel_optimization_iter_)
@@ -1035,9 +1047,7 @@ double Controller::mpc_based_max_vel(const double target_x_vel, geometry_msgs::T
     }
   }
   // Apply limits to the velocity
-  mpc_vel_limit = copysign(1.0, target_x_vel) *
-                      fmin(fabs(target_x_vel), fabs(new_nominal_x_vel));
-  mpc_vel_limit = copysign(1.0, new_nominal_x_vel) *
+  double mpc_vel_limit = copysign(1.0, new_nominal_x_vel) *
                       fmax(fabs(new_nominal_x_vel), mpc_min_x_vel_);
 
   // Revert global variables
@@ -1046,7 +1056,7 @@ double Controller::mpc_based_max_vel(const double target_x_vel, geometry_msgs::T
   return std::abs(mpc_vel_limit);
 }
 
-void Controller::printParameters()
+void Controller::printParameters() const
 {
   ROS_INFO("CONTROLLER PARAMETERS");
   ROS_INFO("-----------------------------------------");
@@ -1190,7 +1200,9 @@ void Controller::setVelMaxExternal(double value)
     return;
   }
   if (value < 0.1)
+  {
     ROS_WARN_THROTTLE(1.0, "External velocity limit is very small (%f), this could result in standstill", value);
+  }
   vel_max_external_ = value;
 }
 

--- a/src/details/derivative_filtered_error_tracker.cpp
+++ b/src/details/derivative_filtered_error_tracker.cpp
@@ -1,0 +1,38 @@
+#include <path_tracking_pid/details/derivative_filtered_error_tracker.hpp>
+
+namespace path_tracking_pid::details
+{
+
+void DerivativeFilteredErrorTracker::push(double value, std::chrono::duration<double> td)
+{
+  errors_.push(value);
+  derivative_errors_.push((errors_.errors().at<0>() - errors_.errors().at<1>()) / td.count());
+}
+
+void DerivativeFilteredErrorTracker::reset()
+{
+  errors_.reset();
+  derivative_errors_.reset();
+}
+
+double DerivativeFilteredErrorTracker::current_error() const
+{
+  return errors_.errors().at<0>();
+}
+
+double DerivativeFilteredErrorTracker::current_filtered_error() const
+{
+  return errors_.filtered_errors().at<0>();
+}
+
+double DerivativeFilteredErrorTracker::current_derivative_error() const
+{
+  return derivative_errors_.errors().at<0>();
+}
+
+double DerivativeFilteredErrorTracker::current_filtered_derivative_error() const
+{
+  return derivative_errors_.filtered_errors().at<0>();
+}
+
+}  // namespace path_tracking_pid::details

--- a/src/details/filtered_error_tracker.cpp
+++ b/src/details/filtered_error_tracker.cpp
@@ -1,0 +1,41 @@
+#include <path_tracking_pid/details/filtered_error_tracker.hpp>
+
+#include <cmath>
+
+namespace path_tracking_pid::details
+{
+
+namespace
+{
+
+// Used in filter calculations. Default 1.0 corresponds to a cutoff frequency at 1/4 of the sample rate.
+constexpr double cutoff = 1.;
+
+}  // namespace
+
+void FilteredErrorTracker::push(double value)
+{
+  errors_.push(value);
+
+  filtered_errors_.push((1 / (1 + cutoff * cutoff + M_SQRT2 * cutoff)) *
+                        (errors_.at<2>() + 2 * errors_.at<1>() + errors_.at<0>() -
+                         (cutoff * cutoff - M_SQRT2 * cutoff + 1) * filtered_errors_.at<1>() -
+                         (-2 * cutoff * cutoff + 2) * filtered_errors_.at<0>()));
+}
+
+void FilteredErrorTracker::reset()
+{
+  errors_.reset();
+  filtered_errors_.reset();
+}
+
+const FifoArray<double, 3>& FilteredErrorTracker::errors() const
+{
+  return errors_;
+}
+const FifoArray<double, 3>& FilteredErrorTracker::filtered_errors() const
+{
+  return filtered_errors_;
+}
+
+}  // namespace path_tracking_pid::details

--- a/src/path_tracking_pid_local_planner.cpp
+++ b/src/path_tracking_pid_local_planner.cpp
@@ -56,11 +56,11 @@ void TrackingPidLocalPlanner::initialize(std::string name, tf2_ros::Buffer* tf, 
   pid_server_->setCallback([this](auto& config, auto) { this->reconfigure_pid(config); });
   pid_controller_.setEnabled(false);
 
-  bool holonomic_robot;
+  bool holonomic_robot = false;
   nh.param<bool>("holonomic_robot", holonomic_robot, false);
   pid_controller_.setHolonomic(holonomic_robot);
 
-  bool estimate_pose_angle;
+  bool estimate_pose_angle = false;
   nh.param<bool>("estimate_pose_angle", estimate_pose_angle, false);
   pid_controller_.setEstimatePoseAngle(estimate_pose_angle);
 
@@ -108,7 +108,9 @@ bool TrackingPidLocalPlanner::setPlan(const std::vector<geometry_msgs::PoseStamp
     geometry_msgs::TransformStamped tf_transform;
     tf_transform = tf_->lookupTransform(map_frame_, path_frame, ros::Time(0));
     // Check alignment, when path-frame is severly mis-aligned show error
-    double yaw, pitch, roll;
+    double yaw = 0;
+    double pitch = 0;
+    double roll = 0;
     tf2::getEulerYPR(tf_transform.transform.rotation, yaw, pitch, roll);
     if (std::fabs(pitch) > MAP_PARALLEL_THRESH || std::fabs(roll) > MAP_PARALLEL_THRESH)
     {
@@ -446,7 +448,8 @@ uint8_t TrackingPidLocalPlanner::projectedCollisionCost()
   // Convert to map coordinates
   for (const auto& point : collision_polygon_hull)
   {
-    int map_x, map_y;
+    int map_x = 0;
+    int map_y = 0;
     costmap2d->worldToMapEnforceBounds(point.x, point.y, map_x, map_y);
     costmap_2d::MapLocation map_point{static_cast<uint>(map_x), static_cast<uint>(map_y)};
     collision_polygon_hull_map.push_back(map_point);

--- a/src/visualization.cpp
+++ b/src/visualization.cpp
@@ -49,7 +49,7 @@ void Visualization::publishPlanPoint(const std_msgs::Header & header, const tf2:
 }
 
 void Visualization::publishSphere(
-  const std_msgs::Header & header, std::string ns, int id, const tf2::Transform & pose,
+  const std_msgs::Header & header, const std::string& ns, int id, const tf2::Transform & pose,
   const std_msgs::ColorRGBA & color)
 {
   geometry_msgs::Pose msg;
@@ -58,7 +58,7 @@ void Visualization::publishSphere(
 }
 
 void Visualization::publishSphere(
-  const std_msgs::Header & header, std::string ns, int id, geometry_msgs::Pose pose,
+  const std_msgs::Header & header, const std::string& ns, int id, geometry_msgs::Pose pose,
   const std_msgs::ColorRGBA & color)
 {
   visualization_msgs::Marker marker;


### PR DESCRIPTION
I noticed there was a lot of code duplication to keep track of error history in ControllerState. I have 3 PRs lined up to address this. This one is the third.

Added a derivative filtered error tracker abstraction. The remaining errors in `ControllerState` are also always tracked in pairs. The 
raw errors/filtered errors and their derivatives. The derivatives are always calculated in the same way. This abstracts that principle to reduce code duplication and noise in the `Controller`.