### PR TITLE
Moved distSquared() helpers.

### DIFF
--- a/include/path_tracking_pid/controller.hpp
+++ b/include/path_tracking_pid/controller.hpp
@@ -196,8 +196,6 @@ public:
   double getVelMaxObstacle() const;
 
 private:
-  static double distSquared(const tf2::Transform& pose_v, const tf2::Transform& pose_w);
-  static double distSquared(const geometry_msgs::Pose& pose_v, const geometry_msgs::Pose& pose_w);
   void distToSegmentSquared(const tf2::Transform& pose_p, const tf2::Transform& pose_v, const tf2::Transform& pose_w,
                             tf2::Transform& pose_projection, double& distance_to_p, double& distance_to_w) const;
 

--- a/src/controller.cpp
+++ b/src/controller.cpp
@@ -49,8 +49,7 @@ tf2::Transform to_transform(const geometry_msgs::Pose & pose)
 // Returns the square distance between two points
 double distSquared(const tf2::Transform & a, const tf2::Transform & b)
 {
-  return std::pow(a.getOrigin().x() - b.getOrigin().x(), 2) +
-         std::pow(a.getOrigin().y() - b.getOrigin().y(), 2);
+  return a.getOrigin().distance2(b.getOrigin());
 }
 
 // Return the square distance between two points.

--- a/src/controller.cpp
+++ b/src/controller.cpp
@@ -46,6 +46,20 @@ tf2::Transform to_transform(const geometry_msgs::Pose & pose)
   return result;
 }
 
+// Returns the square distance between two points
+double distSquared(const tf2::Transform & a, const tf2::Transform & b)
+{
+  return std::pow(a.getOrigin().x() - b.getOrigin().x(), 2) +
+         std::pow(a.getOrigin().y() - b.getOrigin().y(), 2);
+}
+
+// Return the square distance between two points.
+double distSquared(const geometry_msgs::Pose & a, const geometry_msgs::Pose & b)
+{
+  return std::pow(a.position.x - b.position.x, 2) +
+         std::pow(a.position.y - b.position.y, 2);
+}
+
 } // namespace anonymous
 
 void Controller::setHolonomic(bool holonomic)
@@ -254,22 +268,6 @@ void Controller::setPlan(const geometry_msgs::Transform& current_tf, const geome
   setPlan(current_tf, odom_twist, global_plan);
   controller_state_.previous_steering_angle = tf2::getYaw(tf_base_to_steered_wheel.rotation);
   // TODO(clopez) use steering_odom_twist to check if setpoint is being followed
-}
-
-// https://stackoverflow.com/questions/849211/shortest-distance-between-a-point-and-a-line-segment
-// TODO(Cesar): expand to 3 dimensions
-double Controller::distSquared(const tf2::Transform& pose_v, const tf2::Transform& pose_w)
-{
-  // Returns square distance between 2 points
-  return (pose_v.getOrigin().x() - pose_w.getOrigin().x()) * (pose_v.getOrigin().x() - pose_w.getOrigin().x()) +
-         (pose_v.getOrigin().y() - pose_w.getOrigin().y()) * (pose_v.getOrigin().y() - pose_w.getOrigin().y());
-}
-
-double Controller::distSquared(const geometry_msgs::Pose& pose_v, const geometry_msgs::Pose& pose_w)
-{
-  // Returns square distance between 2 points
-  return (pose_v.position.x - pose_w.position.x) * (pose_v.position.x - pose_w.position.x) +
-         (pose_v.position.y - pose_w.position.y) * (pose_v.position.y - pose_w.position.y);
 }
 
 void Controller::distToSegmentSquared(


### PR DESCRIPTION
Moved the `distSquared()` helper functions from static members to the anonymous namespace in the source file.

Will allow me to use them in other helper files in that namespace in the future.

Also refactored the implementation to avoid the duplicate sub-expressions and simply use a library function.