### PR TITLE
Fix possible unsigned underflow

### DIFF
--- a/src/controller.cpp
+++ b/src/controller.cpp
@@ -135,7 +135,7 @@ void Controller::setPlan(geometry_msgs::Transform current_tf, geometry_msgs::Twi
   // For now do not allow repeated points or in-place rotation
   // To allow that the way the progress is checked and the interpolation is done needs to be changed
   // Also check if points suddenly go in the opposite direction, this could lead to deadlocks
-  for (std::vector<geometry_msgs::PoseStamped>::size_type pose_idx = 1; pose_idx < global_plan.size() - 1; ++pose_idx)
+  for (int pose_idx = 1; pose_idx < static_cast<int>(global_plan.size()) - 1; ++pose_idx)
   {
     auto prev_pose = global_plan[pose_idx - 1].pose;
     auto pose = global_plan[pose_idx].pose;
@@ -152,7 +152,7 @@ void Controller::setPlan(geometry_msgs::Transform current_tf, geometry_msgs::Twi
     }
     else
     {
-      ROS_WARN("Pose %zu of path is not used since it is not in the expected direction of the path!", pose_idx);
+      ROS_WARN("Pose %i of path is not used since it is not in the expected direction of the path!", pose_idx);
     }
   }
   // Add last pose as we didn't evaluate that one


### PR DESCRIPTION
When the global plan is empty, this comparison could underflow.

Fix #48