### PR TITLE
Refactored output parameter.

### DIFF
--- a/include/path_tracking_pid/controller.hpp
+++ b/include/path_tracking_pid/controller.hpp
@@ -91,23 +91,22 @@ public:
     const geometry_msgs::Transform & tf_base_to_steered_wheel,
     const geometry_msgs::Twist & steering_odom_twist,
     const std::vector<geometry_msgs::PoseStamped> & global_plan);
+
+  // Result of findPositionOnPlan().
+  struct FindPositionResult
+  {
+    tf2::Transform position;
+    std::size_t path_pose_index = 0;
+  };
+
   /**
    * Find position on plan by looking at the surroundings of last known pose.
    * @param current Where is the robot now?
    * @param controller_state_ptr  The current state of the controller that gets updated by this function
-   * @return tf of found position on plan
-   * @return index of current path-pose if requested
+   * @return tf of found position on plan and the index of current path-pose
    */
-  tf2::Transform findPositionOnPlan(
-    const geometry_msgs::Transform & current_tf, ControllerState * controller_state_ptr,
-    size_t & path_pose_idx);
-  // Overloaded function definition for users that don't require the segment index
-  tf2::Transform findPositionOnPlan(
-    const geometry_msgs::Transform & current_tf, ControllerState * controller_state_ptr)
-  {
-    size_t path_pose_idx;
-    return findPositionOnPlan(current_tf, controller_state_ptr, path_pose_idx);
-  }
+  FindPositionResult findPositionOnPlan(
+    const geometry_msgs::Transform & current_tf, ControllerState * controller_state_ptr);
 
   /**
    * Run one iteration of a PID controller

--- a/src/path_tracking_pid_local_planner.cpp
+++ b/src/path_tracking_pid_local_planner.cpp
@@ -375,12 +375,15 @@ uint8_t TrackingPidLocalPlanner::projectedCollisionCost()
   tf2::Transform projected_step_tf;
   tf2::fromMsg(current_tf, projected_step_tf);
   projected_steps_tf.push_back(projected_step_tf);  // Evaluate collision at base_link
-  projected_step_tf = pid_controller_.findPositionOnPlan(current_tf, &projected_controller_state);
+  projected_step_tf =
+    pid_controller_.findPositionOnPlan(current_tf, &projected_controller_state).position;
   projected_steps_tf.push_back(projected_step_tf);  // Add base_link projected pose
   for (uint step = 0; step < n_steps; step++) {
     tf2::Transform next_straight_step_tf = projected_step_tf * x_step_tf;
-    projected_step_tf = pid_controller_.findPositionOnPlan(
-      tf2::toMsg(next_straight_step_tf), &projected_controller_state);
+    projected_step_tf =
+      pid_controller_
+        .findPositionOnPlan(tf2::toMsg(next_straight_step_tf), &projected_controller_state)
+        .position;
     projected_steps_tf.push_back(projected_step_tf);
 
     // Fill markers:


### PR DESCRIPTION
Refactored the output parameter of `Controller::findPositionOnPlan()` to return value.

See:
- https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#f20-for-out-output-values-prefer-return-values-to-output-parameters
- https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#f21-to-return-multiple-out-values-prefer-returning-a-struct-or-tuple

Please note the following in `Controller::update()` where this function is used:
- instead of two very similar calls to `findPositionOnPlan()` in different branches of the if statement, we now have 1.
- now we declare `path_pose_idx` only once we have a value for it, so we can make it const.
- we use an immediately invoked lambda expression (IILE) to initialize `current_tf_for_find_position`. it has a complex initialization but with the IILE we can do so in one go and make the variable const. see http://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#es28-use-lambdas-for-complex-initialization-especially-of-const-variables
