### PR TITLE
Refactored mandatory ptr parameter to reference.

### DIFF
--- a/include/path_tracking_pid/controller.hpp
+++ b/include/path_tracking_pid/controller.hpp
@@ -94,19 +94,19 @@ public:
   /**
    * Find position on plan by looking at the surroundings of last known pose.
    * @param current Where is the robot now?
-   * @param controller_state_ptr  The current state of the controller that gets updated by this function
+   * @param controller_state  The current state of the controller that gets updated by this function
    * @return tf of found position on plan
    * @return index of current path-pose if requested
    */
   tf2::Transform findPositionOnPlan(
-    const geometry_msgs::Transform & current_tf, ControllerState * controller_state_ptr,
+    const geometry_msgs::Transform & current_tf, ControllerState & controller_state,
     size_t & path_pose_idx);
   // Overloaded function definition for users that don't require the segment index
   tf2::Transform findPositionOnPlan(
-    const geometry_msgs::Transform & current_tf, ControllerState * controller_state_ptr)
+    const geometry_msgs::Transform & current_tf, ControllerState & controller_state)
   {
     size_t path_pose_idx;
-    return findPositionOnPlan(current_tf, controller_state_ptr, path_pose_idx);
+    return findPositionOnPlan(current_tf, controller_state, path_pose_idx);
   }
 
   // Result of update() and update_with_limits().

--- a/src/path_tracking_pid_local_planner.cpp
+++ b/src/path_tracking_pid_local_planner.cpp
@@ -373,12 +373,12 @@ uint8_t TrackingPidLocalPlanner::projectedCollisionCost()
   tf2::Transform projected_step_tf;
   tf2::fromMsg(current_tf, projected_step_tf);
   projected_steps_tf.push_back(projected_step_tf);  // Evaluate collision at base_link
-  projected_step_tf = pid_controller_.findPositionOnPlan(current_tf, &projected_controller_state);
+  projected_step_tf = pid_controller_.findPositionOnPlan(current_tf, projected_controller_state);
   projected_steps_tf.push_back(projected_step_tf);  // Add base_link projected pose
   for (uint step = 0; step < n_steps; step++) {
     tf2::Transform next_straight_step_tf = projected_step_tf * x_step_tf;
     projected_step_tf = pid_controller_.findPositionOnPlan(
-      tf2::toMsg(next_straight_step_tf), &projected_controller_state);
+      tf2::toMsg(next_straight_step_tf), projected_controller_state);
     projected_steps_tf.push_back(projected_step_tf);
 
     // Fill markers:


### PR DESCRIPTION
Refactored a mandatory (nullptr is not allowed) pointer parameter to a reference.

See:
- https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#f17-for-in-out-parameters-pass-by-reference-to-non-const
- https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#f60-prefer-t-over-t-when-no-argument-is-a-valid-option