### PR TITLE
Enable VERBOSE_TESTS

### DIFF
--- a/.github/workflows/industrial_ci_action.yml
+++ b/.github/workflows/industrial_ci_action.yml
@@ -14,4 +14,7 @@ jobs:
     steps:
       - uses: actions/checkout@v1
       - uses: 'ros-industrial/industrial_ci@master'
-        env: ${{matrix.env}}
+        env:
+          ROS_DISTRO: ${{ matrix.env.ROS_DISTRO }}
+          CMAKE_ARGS: ${{ matrix.env.CMAKE_ARGS }}
+          VERBOSE_TESTS: true


### PR DESCRIPTION
If we enable `VERBOSE_TESTS`, you can see which unittests have executed. This gives confidence all the tests are running as expected.

See the logs of the action of the current PR so see how it now looks.