### PR TITLE
Switched distToSegmentSquared() to proper units.

### DIFF
--- a/include/path_tracking_pid/controller.hpp
+++ b/include/path_tracking_pid/controller.hpp
@@ -11,6 +11,7 @@
 #include <boost/noncopyable.hpp>
 #include <path_tracking_pid/details/fifo_array.hpp>
 #include <path_tracking_pid/details/second_order_lowpass.hpp>
+#include <path_tracking_pid/units.hpp>
 #include <vector>
 
 namespace path_tracking_pid
@@ -192,17 +193,18 @@ public:
 private:
   void distToSegmentSquared(
     const tf2::Transform & pose_p, const tf2::Transform & pose_v, const tf2::Transform & pose_w,
-    tf2::Transform & pose_projection, double & distance_to_p, double & distance_to_w) const;
+    tf2::Transform & pose_projection, units::distance_squared_t & distance_to_p,
+    units::distance_t & distance_to_w) const;
 
   // Overloaded function for callers that don't need the additional results
-  double distToSegmentSquared(
+  units::distance_squared_t distToSegmentSquared(
     const tf2::Transform & pose_p, const tf2::Transform & pose_v,
     const tf2::Transform & pose_w) const
   {
     tf2::Transform dummy_tf;
-    double dummy_double;
-    double result;
-    distToSegmentSquared(pose_p, pose_v, pose_w, dummy_tf, result, dummy_double);
+    units::distance_t dummy_distance;
+    units::distance_squared_t result;
+    distToSegmentSquared(pose_p, pose_v, pose_w, dummy_tf, result, dummy_distance);
     return result;
   }
 

--- a/include/path_tracking_pid/units.hpp
+++ b/include/path_tracking_pid/units.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <boost/units/cmath.hpp>
 #include <boost/units/systems/si.hpp>
 
 namespace path_tracking_pid::units
@@ -27,10 +28,10 @@ using acceleration_t = boost::units::quantity<boost::units::si::acceleration, do
 // auto v1 = 23.0 * square_meter;  // type of v1 is distance_squared_t
 // auto v2 = 5 * meter_per_second; // type of v1 is boost::units::quantity<boost::units::si::velocity, int>
 // ```
-using boost::units::si::meter;
-using boost::units::si::meter_per_second;
-using boost::units::si::meter_per_second_squared;
-using boost::units::si::second;
-using boost::units::si::square_meter;
+inline const auto meter = boost::units::si::meter;
+inline const auto meter_per_second = boost::units::si::meter_per_second;
+inline const auto meter_per_second_squared = boost::units::si::meter_per_second_squared;
+inline const auto second = boost::units::si::second;
+inline const auto square_meter = boost::units::si::square_meter;
 
 }  // namespace path_tracking_pid::units

--- a/include/path_tracking_pid/units.hpp
+++ b/include/path_tracking_pid/units.hpp
@@ -1,0 +1,36 @@
+#pragma once
+
+#include <boost/units/systems/si.hpp>
+
+namespace path_tracking_pid::units
+{
+
+// Distance in meter.
+using distance_t = boost::units::quantity<boost::units::si::length, double>;
+
+// Distance squared in square meter.
+using distance_squared_t = boost::units::quantity<boost::units::si::area, double>;
+
+// Duration in second.
+using duration_t = boost::units::quantity<boost::units::si::time, double>;
+
+// Velocity in meter per second.
+using velocity_t = boost::units::quantity<boost::units::si::velocity, double>;
+
+// Acceleration in meter per second squared.
+using acceleration_t = boost::units::quantity<boost::units::si::acceleration, double>;
+
+// The following units can be used to create quantities from raw values. Please note that the type
+// of the raw value is used for the value type of the quantity.
+// Example:
+// ```cpp
+// auto v1 = 23.0 * square_meter;  // type of v1 is distance_squared_t
+// auto v2 = 5 * meter_per_second; // type of v1 is boost::units::quantity<boost::units::si::velocity, int>
+// ```
+using boost::units::si::meter;
+using boost::units::si::meter_per_second;
+using boost::units::si::meter_per_second_squared;
+using boost::units::si::second;
+using boost::units::si::square_meter;
+
+}  // namespace path_tracking_pid::units


### PR DESCRIPTION
Boot Units are go! 🚀 This will be the first PR in a series. I will change a few functions and/or variables per PR. This keeps the changes small and easy to review. Gradually all conversions from (`.value()`) and to (`* units::meter`) the strong types will move to the outer edges of the code.

Changed `Controller::distToSegmentSquared()` to Boost Units.