### PR TITLE
Refactored distToSegmentSquared().

### DIFF
--- a/src/controller.cpp
+++ b/src/controller.cpp
@@ -36,14 +36,6 @@ bool have_same_sign(T val1, T val2)
   return std::signbit(val1) == std::signbit(val2);
 }
 
-// Floating-point aware version of std::clamp(). fclamp() is to std::clamp() what std::fmin() and
-// std::fmax() are to std::min() and std::max().
-template <typename T>
-T fclamp(T value, T low, T high)
-{
-  return std::fmax(low, std::fmin(value, high));
-}
-
 // Converts a pose to the corresponding transform.
 tf2::Transform to_transform(const geometry_msgs::Pose & pose)
 {
@@ -306,7 +298,7 @@ Controller::DistToSegmentSquaredResult Controller::distToSegmentSquared(
 
   DistToSegmentSquaredResult result;
 
-  const double t = fclamp(
+  const double t = std::clamp(
     ((pose_p.getOrigin().x() - pose_v.getOrigin().x()) *
        (pose_w.getOrigin().x() - pose_v.getOrigin().x()) +
      (pose_p.getOrigin().y() - pose_v.getOrigin().y()) *

--- a/src/controller.cpp
+++ b/src/controller.cpp
@@ -36,6 +36,14 @@ bool have_same_sign(T val1, T val2)
   return std::signbit(val1) == std::signbit(val2);
 }
 
+// Floating-point aware version of std::clamp(). fclamp() is to std::clamp() what std::fmin() and
+// std::fmax() are to std::min() and std::max().
+template <typename T>
+T fclamp(T value, T low, T high)
+{
+  return std::fmax(low, std::fmin(value, high));
+}
+
 // Converts a pose to the corresponding transform.
 tf2::Transform to_transform(const geometry_msgs::Pose & pose)
 {
@@ -285,41 +293,40 @@ void Controller::setPlan(
 Controller::DistToSegmentSquaredResult Controller::distToSegmentSquared(
   const tf2::Transform & pose_p, const tf2::Transform & pose_v, const tf2::Transform & pose_w) const
 {
-  DistToSegmentSquaredResult result;
-
   const double l2 = distSquared(pose_v, pose_w);
   if (l2 == 0) {
+    DistToSegmentSquaredResult result;
+
     result.pose_projection = pose_w;
     result.distance_to_w = 0.0;
     result.distance2_to_p = distSquared(pose_p, pose_w);
-  } else {
-    double t = ((pose_p.getOrigin().x() - pose_v.getOrigin().x()) *
-                  (pose_w.getOrigin().x() - pose_v.getOrigin().x()) +
-                (pose_p.getOrigin().y() - pose_v.getOrigin().y()) *
-                  (pose_w.getOrigin().y() - pose_v.getOrigin().y())) /
-               l2;
-    t = fmax(0.0, fmin(1.0, t));
-    result.pose_projection.setOrigin(tf2::Vector3(
-      pose_v.getOrigin().x() + t * (pose_w.getOrigin().x() - pose_v.getOrigin().x()),
-      pose_v.getOrigin().y() + t * (pose_w.getOrigin().y() - pose_v.getOrigin().y()), 0.0));
-    double yaw_projection = tf2::getYaw(pose_v.getRotation());  // get yaw of the first vector + t *
-      // (tf2::getYaw(pose_w.getRotation()) -
-      // tf2::getYaw(pose_v.getRotation()));
-    tf2::Quaternion pose_quaternion;
-    if (estimate_pose_angle_enabled_) {
-      pose_quaternion.setRPY(
-        0.0, 0.0,
-        atan2(
-          pose_w.getOrigin().y() - pose_v.getOrigin().y(),
-          pose_w.getOrigin().x() - pose_v.getOrigin().x()));
-    } else {
-      pose_quaternion.setRPY(0.0, 0.0, yaw_projection);
-    }
 
-    result.pose_projection.setRotation(pose_quaternion);
-    result.distance_to_w = sqrt(distSquared(result.pose_projection, pose_w));
-    result.distance2_to_p = distSquared(pose_p, result.pose_projection);
+    return result;
   }
+
+  DistToSegmentSquaredResult result;
+
+  const double t = fclamp(
+    ((pose_p.getOrigin().x() - pose_v.getOrigin().x()) *
+       (pose_w.getOrigin().x() - pose_v.getOrigin().x()) +
+     (pose_p.getOrigin().y() - pose_v.getOrigin().y()) *
+       (pose_w.getOrigin().y() - pose_v.getOrigin().y())) /
+      l2,
+    0.0, 1.0);
+  result.pose_projection.setOrigin(tf2::Vector3(
+    pose_v.getOrigin().x() + t * (pose_w.getOrigin().x() - pose_v.getOrigin().x()),
+    pose_v.getOrigin().y() + t * (pose_w.getOrigin().y() - pose_v.getOrigin().y()), 0.0));
+
+  const auto yaw = estimate_pose_angle_enabled_ ? atan2(
+                                                    pose_w.getOrigin().y() - pose_v.getOrigin().y(),
+                                                    pose_w.getOrigin().x() - pose_v.getOrigin().x())
+                                                : tf2::getYaw(pose_v.getRotation());
+  tf2::Quaternion pose_quaternion;
+  pose_quaternion.setRPY(0.0, 0.0, yaw);
+  result.pose_projection.setRotation(pose_quaternion);
+
+  result.distance_to_w = sqrt(distSquared(result.pose_projection, pose_w));
+  result.distance2_to_p = distSquared(pose_p, result.pose_projection);
 
   return result;
 }


### PR DESCRIPTION
Refactored `Controller::distToSegmentSquared()`.

Some of the changes:
- prefer early returns over long/nested ifs: https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#f56-avoid-unnecessary-condition-nesting
- prefer const for local variables: https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#con1-by-default-make-objects-immutable
- removed incorrect (or outdated?) comment