### PR TITLE
Removed global_plan_ member.

### DIFF
--- a/include/path_tracking_pid/path_tracking_pid_local_planner.hpp
+++ b/include/path_tracking_pid/path_tracking_pid_local_planner.hpp
@@ -123,7 +123,6 @@ private:
   ros::Duration prev_dt_;
   path_tracking_pid::Controller pid_controller_;
 
-  std::vector<geometry_msgs::PoseStamped> global_plan_;
   nav_msgs::Path received_path_;
 
   // Obstacle collision detection


### PR DESCRIPTION
Last PR to fix #97 - removed `TrackingPidLocalPlanner::global_plan_` member variable.

Please check this one carefully. @Rayman _thought_ not republishing the plan in `TrackingPidLocalPlanner::reconfigure_pid()` would be ok, but wasn't entirely sure.