### PR TITLE
Keep clang-tidy happy.

### DIFF
--- a/src/calculations.cpp
+++ b/src/calculations.cpp
@@ -8,17 +8,17 @@
 namespace path_tracking_pid
 {
 
-std::vector<tf2::Transform> deltas_of_plan(const std::vector<tf2::Transform> & input)
+std::vector<tf2::Transform> deltas_of_plan(const std::vector<tf2::Transform> & plan)
 {
   auto result = std::vector<tf2::Transform>{};
 
-  if (input.size() < 2) {
+  if (plan.size() < 2) {
     return result;
   }
 
-  result.reserve(input.size() - 1);
+  result.reserve(plan.size() - 1);
   std::transform(
-    input.cbegin(), input.cend() - 1, input.cbegin() + 1, std::back_inserter(result),
+    plan.cbegin(), plan.cend() - 1, plan.cbegin() + 1, std::back_inserter(result),
     [](const tf2::Transform & a, const tf2::Transform & b) { return a.inverseTimes(b); });
 
   return result;


### PR DESCRIPTION
Small fix to keep clang-tidy happy. (Parameter name was different in header and source.)