### PR TITLE
Refactor collision visualization functions

### DIFF
--- a/include/path_tracking_pid/visualization.hpp
+++ b/include/path_tracking_pid/visualization.hpp
@@ -32,11 +32,11 @@ private:
   ros::Publisher marker_pub_;
 
   void publishSphere(
-    const std_msgs::Header & header, const std::string & ns, int id, const tf2::Transform & pose,
+    const std_msgs::Header & header, const std::string & ns, const tf2::Transform & pose,
     const std_msgs::ColorRGBA & color);
   void publishSphere(
-    const std_msgs::Header & header, const std::string & ns, int id,
-    const geometry_msgs::Pose & pose, const std_msgs::ColorRGBA & color);
+    const std_msgs::Header & header, const std::string & ns, const geometry_msgs::Pose & pose,
+    const std_msgs::ColorRGBA & color);
 };
 
 }  // namespace path_tracking_pid

--- a/include/path_tracking_pid/visualization.hpp
+++ b/include/path_tracking_pid/visualization.hpp
@@ -4,29 +4,32 @@
 #include <tf2/LinearMath/Transform.h>
 
 #include <string>
+#include <vector>
 
 namespace path_tracking_pid
 {
-
 class Visualization
 {
 public:
-  using point_t = geometry_msgs::Point;
-  using points_t = std::vector<point_t>;
-
   explicit Visualization(ros::NodeHandle nh);
 
   void publishControlPoint(const std_msgs::Header & header, const tf2::Transform & pose);
   void publishAxlePoint(const std_msgs::Header & header, const tf2::Transform & pose);
   void publishGoalPoint(const std_msgs::Header & header, const tf2::Transform & pose);
   void publishPlanPoint(const std_msgs::Header & header, const tf2::Transform & pose);
-  void publishCollision(
-    const std::string & frame_id, uint8_t cost, const point_t & point, const points_t & footprint,
-    const points_t & hull, const points_t & steps, const points_t & path);
+  void publishCollisionObject(
+    const std_msgs::Header & header, uint8_t cost, const tf2::Vector3 & point);
+  void publishExtrapolatedPoses(
+    const std_msgs::Header & header, const std::vector<tf2::Vector3> & steps);
+  void publishgGoalPosesOnPath(
+    const std_msgs::Header & header, const std::vector<tf2::Vector3> & path);
+  void publishCollisionFootprint(
+    const std_msgs::Header & header, const std::vector<tf2::Vector3> & footprint);
+  void publishCollisionPolygon(
+    const std_msgs::Header & header, const std::vector<tf2::Vector3> & hull);
 
 private:
   ros::Publisher marker_pub_;
-  ros::Publisher collision_marker_pub_;
 
   void publishSphere(
     const std_msgs::Header & header, const std::string & ns, int id, const tf2::Transform & pose,

--- a/src/visualization.cpp
+++ b/src/visualization.cpp
@@ -10,6 +10,17 @@
 
 namespace path_tracking_pid
 {
+std::vector<geometry_msgs::Point> to_msg(std::vector<tf2::Vector3> points)
+{
+  std::vector<geometry_msgs::Point> msgs;
+  std::transform(points.begin(), points.end(), std::back_inserter(msgs), [](const auto & msg) {
+    geometry_msgs::Point p;
+    tf2::toMsg(msg, p);
+    return p;
+  });
+  return msgs;
+}
+
 Visualization::Visualization(ros::NodeHandle nh)
 : marker_pub_{nh.advertise<visualization_msgs::Marker>("visualization_marker", 10)}
 {
@@ -88,14 +99,7 @@ void Visualization::publishExtrapolatedPoses(
   marker.color.r = 1.0;
   marker.color.g = 0.5;
   marker.color.a = 1.0;
-
-  std::transform(
-    steps.begin(), steps.end(), std::back_inserter(marker.points), [](const auto & step) {
-      geometry_msgs::Point p;
-      tf2::toMsg(step, p);
-      return p;
-    });
-
+  marker.points = to_msg(steps);
   marker_pub_.publish(marker);
 }
 
@@ -113,14 +117,7 @@ void Visualization::publishgGoalPosesOnPath(
   marker.color.r = 1.0;
   marker.color.g = 1.0;
   marker.color.a = 1.0;
-
-  std::transform(
-    path.begin(), path.end(), std::back_inserter(marker.points), [](const auto & step) {
-      geometry_msgs::Point p;
-      tf2::toMsg(step, p);
-      return p;
-    });
-
+  marker.points = to_msg(path);
   marker_pub_.publish(marker);
 }
 
@@ -136,14 +133,7 @@ void Visualization::publishCollisionFootprint(
   marker.scale.x = 0.1;
   marker.color.b = 1.0;
   marker.color.a = 0.3;
-
-  std::transform(
-    footprint.begin(), footprint.end(), std::back_inserter(marker.points), [](const auto & step) {
-      geometry_msgs::Point p;
-      tf2::toMsg(step, p);
-      return p;
-    });
-
+  marker.points = to_msg(footprint);
   marker_pub_.publish(marker);
 }
 
@@ -159,14 +149,7 @@ void Visualization::publishCollisionPolygon(
   marker.scale.x = 0.2;
   marker.color.r = 1.0;
   marker.color.a = 0.3;
-
-  std::transform(
-    hull.begin(), hull.end(), std::back_inserter(marker.points), [](const auto & step) {
-      geometry_msgs::Point p;
-      tf2::toMsg(step, p);
-      return p;
-    });
-
+  marker.points = to_msg(hull);
   marker_pub_.publish(marker);
 }
 

--- a/src/visualization.cpp
+++ b/src/visualization.cpp
@@ -10,6 +10,24 @@
 
 namespace path_tracking_pid
 {
+// Factory function for a visualization color from the given arguments. (Because the corresponding
+// type has no appropriate constructor.)
+std_msgs::ColorRGBA create_color(float r, float g, float b, float a = 1)
+{
+  std_msgs::ColorRGBA color;
+  color.r = r;
+  color.g = g;
+  color.b = b;
+  color.a = a;
+  return color;
+}
+
+const auto red = create_color(1, 0, 0);
+const auto green = create_color(0, 1, 0);
+const auto blue = create_color(1, 0, 1);
+const auto yellow = create_color(1, 1, 0);
+const auto orange = create_color(1, 0.5, 0);
+
 std::vector<geometry_msgs::Point> to_msg(std::vector<tf2::Vector3> points)
 {
   std::vector<geometry_msgs::Point> msgs;
@@ -29,35 +47,24 @@ Visualization::Visualization(ros::NodeHandle nh)
 void Visualization::publishControlPoint(
   const std_msgs::Header & header, const tf2::Transform & pose)
 {
-  std_msgs::ColorRGBA color;
-  color.a = 1.0;
-  color.g = 1.0;
-  publishSphere(header, "control point", pose, color);
+  publishSphere(header, "control point", pose, green);
 }
 
 void Visualization::publishAxlePoint(const std_msgs::Header & header, const tf2::Transform & pose)
 {
   std_msgs::ColorRGBA color;
-  color.a = 1.0;
-  color.b = 1.0;
-  publishSphere(header, "axle point", pose, color);
+  publishSphere(header, "axle point", pose, blue);
 }
 
 void Visualization::publishGoalPoint(const std_msgs::Header & header, const tf2::Transform & pose)
 {
   std_msgs::ColorRGBA color;
-  color.a = 1.0;
-  color.r = 1.0;
-  publishSphere(header, "goal point", pose, color);
+  publishSphere(header, "goal point", pose, red);
 }
 
 void Visualization::publishPlanPoint(const std_msgs::Header & header, const tf2::Transform & pose)
 {
-  std_msgs::ColorRGBA color;
-  color.a = 1.0;
-  color.g = 0.5;
-  color.r = 1.0;
-  publishSphere(header, "plan point", pose, color);
+  publishSphere(header, "plan point", pose, orange);
 }
 
 void Visualization::publishCollisionObject(
@@ -70,10 +77,9 @@ void Visualization::publishCollisionObject(
   marker.type = visualization_msgs::Marker::CYLINDER;
   marker.scale.x = 0.5;
   marker.scale.y = 0.5;
-  marker.color.r = 1.0;
-  marker.color.a = 0.0;
-  marker.scale.z = cost / 255.0;
+  marker.color = red;
   marker.color.a = cost / 255.0;
+  marker.scale.z = cost / 255.0;
   tf2::toMsg(point, marker.pose.position);
   marker.pose.position.z = marker.scale.z * 0.5;
   if (marker.scale.z > std::numeric_limits<float>::epsilon()) {
@@ -96,9 +102,7 @@ void Visualization::publishExtrapolatedPoses(
   marker.type = visualization_msgs::Marker::POINTS;
   marker.scale.x = 0.5;
   marker.scale.y = 0.5;
-  marker.color.r = 1.0;
-  marker.color.g = 0.5;
-  marker.color.a = 1.0;
+  marker.color = orange;
   marker.points = to_msg(steps);
   marker_pub_.publish(marker);
 }
@@ -114,9 +118,7 @@ void Visualization::publishgGoalPosesOnPath(
   marker.type = visualization_msgs::Marker::POINTS;
   marker.scale.x = 0.5;
   marker.scale.y = 0.5;
-  marker.color.r = 1.0;
-  marker.color.g = 1.0;
-  marker.color.a = 1.0;
+  marker.color = yellow;
   marker.points = to_msg(path);
   marker_pub_.publish(marker);
 }
@@ -131,7 +133,7 @@ void Visualization::publishCollisionFootprint(
   marker.pose.orientation.w = 1.0;
   marker.type = visualization_msgs::Marker::LINE_LIST;
   marker.scale.x = 0.1;
-  marker.color.b = 1.0;
+  marker.color = blue;
   marker.color.a = 0.3;
   marker.points = to_msg(footprint);
   marker_pub_.publish(marker);
@@ -147,7 +149,7 @@ void Visualization::publishCollisionPolygon(
   marker.pose.orientation.w = 1.0;
   marker.type = visualization_msgs::Marker::LINE_STRIP;
   marker.scale.x = 0.2;
-  marker.color.r = 1.0;
+  marker.color = red;
   marker.color.a = 0.3;
   marker.points = to_msg(hull);
   marker_pub_.publish(marker);

--- a/src/visualization.cpp
+++ b/src/visualization.cpp
@@ -21,8 +21,7 @@ void Visualization::publishControlPoint(
   std_msgs::ColorRGBA color;
   color.a = 1.0;
   color.g = 1.0;
-  // id has to be unique, so using a compile-time counter :)
-  publishSphere(header, "control point", __COUNTER__, pose, color);
+  publishSphere(header, "control point", pose, color);
 }
 
 void Visualization::publishAxlePoint(const std_msgs::Header & header, const tf2::Transform & pose)
@@ -30,7 +29,7 @@ void Visualization::publishAxlePoint(const std_msgs::Header & header, const tf2:
   std_msgs::ColorRGBA color;
   color.a = 1.0;
   color.b = 1.0;
-  publishSphere(header, "axle point", __COUNTER__, pose, color);
+  publishSphere(header, "axle point", pose, color);
 }
 
 void Visualization::publishGoalPoint(const std_msgs::Header & header, const tf2::Transform & pose)
@@ -38,7 +37,7 @@ void Visualization::publishGoalPoint(const std_msgs::Header & header, const tf2:
   std_msgs::ColorRGBA color;
   color.a = 1.0;
   color.r = 1.0;
-  publishSphere(header, "goal point", __COUNTER__, pose, color);
+  publishSphere(header, "goal point", pose, color);
 }
 
 void Visualization::publishPlanPoint(const std_msgs::Header & header, const tf2::Transform & pose)
@@ -47,7 +46,7 @@ void Visualization::publishPlanPoint(const std_msgs::Header & header, const tf2:
   color.a = 1.0;
   color.g = 0.5;
   color.r = 1.0;
-  publishSphere(header, "plan point", __COUNTER__, pose, color);
+  publishSphere(header, "plan point", pose, color);
 }
 
 void Visualization::publishCollisionObject(
@@ -57,7 +56,6 @@ void Visualization::publishCollisionObject(
   marker.header = header;
   marker.ns = "Collision object";
   marker.pose.orientation.w = 1.0;
-  marker.id = __COUNTER__;
   marker.type = visualization_msgs::Marker::CYLINDER;
   marker.scale.x = 0.5;
   marker.scale.y = 0.5;
@@ -84,7 +82,6 @@ void Visualization::publishExtrapolatedPoses(
   marker.ns = "extrapolated poses";
   marker.action = visualization_msgs::Marker::ADD;
   marker.pose.orientation.w = 1.0;
-  marker.id = __COUNTER__;
   marker.type = visualization_msgs::Marker::POINTS;
   marker.scale.x = 0.5;
   marker.scale.y = 0.5;
@@ -110,7 +107,6 @@ void Visualization::publishgGoalPosesOnPath(
   marker.ns = "goal poses on path";
   marker.action = visualization_msgs::Marker::ADD;
   marker.pose.orientation.w = 1.0;
-  marker.id = __COUNTER__;
   marker.type = visualization_msgs::Marker::POINTS;
   marker.scale.x = 0.5;
   marker.scale.y = 0.5;
@@ -136,7 +132,6 @@ void Visualization::publishCollisionFootprint(
   marker.ns = "Collision footprint";
   marker.action = visualization_msgs::Marker::ADD;
   marker.pose.orientation.w = 1.0;
-  marker.id = __COUNTER__;
   marker.type = visualization_msgs::Marker::LINE_LIST;
   marker.scale.x = 0.1;
   marker.color.b = 1.0;
@@ -160,7 +155,6 @@ void Visualization::publishCollisionPolygon(
   marker.ns = "Collision polygon";
   marker.action = visualization_msgs::Marker::ADD;
   marker.pose.orientation.w = 1.0;
-  marker.id = __COUNTER__;
   marker.type = visualization_msgs::Marker::LINE_STRIP;
   marker.scale.x = 0.2;
   marker.color.r = 1.0;
@@ -177,22 +171,21 @@ void Visualization::publishCollisionPolygon(
 }
 
 void Visualization::publishSphere(
-  const std_msgs::Header & header, const std::string & ns, int id, const tf2::Transform & pose,
+  const std_msgs::Header & header, const std::string & ns, const tf2::Transform & pose,
   const std_msgs::ColorRGBA & color)
 {
   geometry_msgs::Pose msg;
   tf2::toMsg(pose, msg);
-  publishSphere(header, ns, id, msg, color);
+  publishSphere(header, ns, msg, color);
 }
 
 void Visualization::publishSphere(
-  const std_msgs::Header & header, const std::string & ns, int id, const geometry_msgs::Pose & pose,
+  const std_msgs::Header & header, const std::string & ns, const geometry_msgs::Pose & pose,
   const std_msgs::ColorRGBA & color)
 {
   visualization_msgs::Marker marker;
   marker.header = header;
   marker.ns = ns;
-  marker.id = id;
   marker.type = visualization_msgs::Marker::SPHERE;
   marker.action = visualization_msgs::Marker::ADD;
   marker.pose = pose;


### PR DESCRIPTION
I did an alternative refactor to #107.

- I've split the main function up in several small functions
- I've moved `ros::Time::now()` calls away from the visualization class
- I've used `tf2` datatypes if possible
- I've published everything on a single visualization topic