### PR TITLE
Made Controller::findPositionOnPlan() const.

### DIFF
--- a/include/path_tracking_pid/controller.hpp
+++ b/include/path_tracking_pid/controller.hpp
@@ -101,16 +101,17 @@ public:
   {
     tf2::Transform position;
     std::size_t path_pose_idx = 0;
+    double distance_to_goal = 0;
   };
 
   /**
    * Find position on plan by looking at the surroundings of last known pose.
    * @param current Where is the robot now?
    * @param controller_state  The current state of the controller that gets updated by this function
-   * @return Found position on plan and the index of current path-pose
+   * @return Found position on plan, index of current path-pose and the distance to the goal.
    */
   FindPositionOnPlanResult findPositionOnPlan(
-    const tf2::Transform & current_tf, ControllerState & controller_state);
+    const tf2::Transform & current_tf, ControllerState & controller_state) const;
 
   // Result of update() and update_with_limits().
   struct UpdateResult


### PR DESCRIPTION
Next PR to fix #123 .

Refactored `Controller::findPositionOnPlan()`:
- data member `distance_to_goal_` is now no longer set but returned as (part of) the return value.
- callers which run this as a simulation (those in `PathTrackingPlanner`) ignore this
- other callers update the data member after the call
- the member function is now `const`